### PR TITLE
Graphs module

### DIFF
--- a/paynt/paynt/utils/graphs.py
+++ b/paynt/paynt/utils/graphs.py
@@ -1,0 +1,75 @@
+import re
+import pygraphviz as pgv
+
+def parse_hole(name) -> object:
+    hole = {}
+    hole["type"] = "Memory" if name[0] == "M" else "Assignment"
+    hole["memory"] = int(name[-2])
+    hole["observation"] = int(name[5]) if re.match(
+        r"[MA]\(\[o=\d\],\d\)", name) else 0
+
+    return hole
+
+
+class Graph:
+    """A class for creating graphs from design space structures.
+    """
+
+    def __init__(self) -> None:
+        """Initializes an instance of the Graph class.
+        """
+        self.graph = pgv.AGraph(strict=False, directed=True)
+
+    def parse(self, design_space) -> None:
+        """Parses the design space holes into the nodes dictionary:
+                {start_node: {end_node1: [observation1],...}, end_node2: ...}
+
+            design_space: list of holes
+        """
+        self.nodes = {}
+        for hole in design_space:
+            tmp = parse_hole(hole.name)
+            tmp["next"] = list(hole.options)
+
+            for next in tmp["next"]:
+                if tmp["type"] == "Assignment":
+                    continue
+
+                if tmp["memory"] in self.nodes.keys():
+                    if next in self.nodes[tmp["memory"]].keys():
+                        self.nodes[tmp["memory"]][next].append(
+                            tmp["observation"])
+                    else:
+                        self.nodes[tmp["memory"]][next] = [tmp["observation"]]
+                else:
+                    self.nodes[tmp["memory"]] = {next: [tmp["observation"]]}
+
+    def create_graph(self, show_labels=False) -> None:
+        """Creates a graph from the parsed design space.
+        """
+        self.graph.clear()
+        nodes = list(self.nodes.keys())
+        self.graph.add_nodes_from(nodes, fontsize=12, width=0.5, height=0.5)
+
+        for (start, ends) in self.nodes.items():
+            for (end, labels) in ends.items():
+                if show_labels:
+                    self.graph.add_edge(start, end, label=",".join(
+                        [str(l) for l in sorted(labels)]), fontsize=12)
+                else:
+                    self.graph.add_edge(start, end)
+        self.graph.layout("circo")
+
+    def print(self, design_space, file_name="out", show_labels=False, args="-Gsize=5! -Gratio=\"expand\" -Gnodesep=.5") -> None:
+        """Prints a graph in .png format.
+
+            design_space: list of Holes
+            file_name: name of file where the graph will be saved without the extention (e.g. file_name=file => file.png)
+            args: string with Graphvix arguments to specify the output format
+        """
+        self.parse(design_space)
+        self.create_graph(show_labels=show_labels)
+        self.graph.draw(file_name + ".png", format="png", args=args)
+
+    def __str__(self) -> str:
+        return self.graph.string()

--- a/prerequisites/.gitignore
+++ b/prerequisites/.gitignore
@@ -1,3 +1,5 @@
 carl/
 pycarl/
 cvc5/
+carl-master14/
+pycarl-2.0.5/


### PR DESCRIPTION
While working with PAYNT, I found myself endlessly drawing models to make sense of what the output looked like. To spare some time, I used [Graphviz](https://pygraphviz.github.io/) for drawing the model for me.

You can draw the result, the initial design space, or any list of Holes like this:
```
from .utils.graps import Graph

Graph().print(design_space)
```
if `design_space` was the result of
```
python3 paynt/paynt.py --project workspace/examples/pomdp/grid/avoid ar --pomdp
```
```
 A([o=1],0)={'east'}, A([o=1],1)={'east'}, A([o=1],2)={'south'}, M([o=1],0)=1, M([o=1],1)=2, M([o=1],2)=0, M([],0)=0, M([],1)=0, M([],2)=0, M([o=3],0)=0, M([o=3],1)=0, M([o=3],2)=0, M([o=2],0)=0, M([o=2],1)=0, M([o=2],2)=0
```
the output would be a PNG image looking like this:
![out](https://user-images.githubusercontent.com/19515281/155371235-2d6987cc-0d96-4803-b932-0bd6d6b6c56a.png)

(Nodes are the current memory values, edges are possible observations)

**Note**: the parsing function expects hole names in the format of `M([o=0],0)` or `M([],0)` and might not work properly if that is not the case.