### PR TITLE
Update prerequisites .gitignore

### DIFF
--- a/prerequisites/.gitignore
+++ b/prerequisites/.gitignore
@@ -1,3 +1,5 @@
 carl/
 pycarl/
 cvc5/
+carl-master14/
+pycarl-2.0.5/


### PR DESCRIPTION
I would like to update the `.gitignore` file for prerequisites so that the contents of `carl-master14/` and `pycarl-2.0.5` don't show up in changes after installation.