### PR TITLE
Restrictions and graphs

### DIFF
--- a/paynt/paynt/utils/graphs.py
+++ b/paynt/paynt/utils/graphs.py
@@ -2,7 +2,7 @@ import re
 import pygraphviz as pgv
 
 def parse_hole(name) -> object:
-    assert re.match(r"[AM]\(\[(o=\d)?\],\d\)",
+    assert re.match(r"[AM]\(\[.*\],\d\)",
                     name), "Cannot use restrict function, hole name doesn't match"
     hole = {}
     hole["type"] = "Memory" if name[0] == "M" else "Assignment"

--- a/paynt/paynt/utils/graphs.py
+++ b/paynt/paynt/utils/graphs.py
@@ -1,0 +1,77 @@
+import re
+import pygraphviz as pgv
+
+def parse_hole(name) -> object:
+    assert re.match(r"[AM]\(\[(o=\d)?\],\d\)",
+                    name), "Cannot use restrict function, hole name doesn't match"
+    hole = {}
+    hole["type"] = "Memory" if name[0] == "M" else "Assignment"
+    hole["memory"] = int(name[-2])
+    hole["observation"] = int(name[5]) if re.match(
+        r"[MA]\(\[o=\d\],\d\)", name) else 0
+
+    return hole
+
+
+class Graph:
+    """A class for creating graphs from design space structures.
+    """
+
+    def __init__(self) -> None:
+        """Initializes an instance of the Graph class.
+        """
+        self.graph = pgv.AGraph(strict=False, directed=True)
+
+    def parse(self, design_space) -> None:
+        """Parses the design space holes into the nodes dictionary:
+                {start_node: {end_node1: [observation1],...}, end_node2: ...}
+
+            design_space: list of holes
+        """
+        self.nodes = {}
+        for hole in design_space:
+            tmp = parse_hole(hole.name)
+            tmp["next"] = list(hole.options)
+
+            for next in tmp["next"]:
+                if tmp["type"] == "Assignment":
+                    continue
+
+                if tmp["memory"] in self.nodes.keys():
+                    if next in self.nodes[tmp["memory"]].keys():
+                        self.nodes[tmp["memory"]][next].append(
+                            tmp["observation"])
+                    else:
+                        self.nodes[tmp["memory"]][next] = [tmp["observation"]]
+                else:
+                    self.nodes[tmp["memory"]] = {next: [tmp["observation"]]}
+
+    def create_graph(self, show_labels=False) -> None:
+        """Creates a graph from the parsed design space.
+        """
+        self.graph.clear()
+        nodes = list(self.nodes.keys())
+        self.graph.add_nodes_from(nodes, fontsize=12, width=0.5, height=0.5)
+
+        for (start, ends) in self.nodes.items():
+            for (end, labels) in ends.items():
+                if show_labels:
+                    self.graph.add_edge(start, end, label=",".join(
+                        [str(l) for l in sorted(labels)]), fontsize=12)
+                else:
+                    self.graph.add_edge(start, end)
+        self.graph.layout("circo")
+
+    def print(self, design_space, file_name="out", show_labels=False, args="-Gsize=5! -Gratio=\"expand\" -Gnodesep=.5") -> None:
+        """Prints a graph in .png format.
+
+            design_space: list of Holes
+            file_name: name of file where the graph will be saved without the extention (e.g. file_name=file => file.png)
+            args: string with Graphvix arguments to specify the output format
+        """
+        self.parse(design_space)
+        self.create_graph(show_labels=show_labels)
+        self.graph.draw(file_name + ".png", format="png", args=args)
+
+    def __str__(self) -> str:
+        return self.graph.string()

--- a/paynt/paynt/utils/restriction_conditions.py
+++ b/paynt/paynt/utils/restriction_conditions.py
@@ -1,0 +1,76 @@
+
+import re
+
+
+class RestrictionConditions:
+    conditions = {}
+
+    def __init__(self) -> None:
+        self.conditions = {
+            "original": self.cond0,
+            "greater_or_zero": self.cond1,
+            "one_step_at_a_time": self.cond2,
+            "one_step_circular": self.cond3,
+            "circular_one_way": self.cond4,
+            "experiment": self.cond5,
+            "no_self_loop": self.cond6,
+        }
+
+    def cond0(self, *_):
+        return False
+
+    def cond1(self, current, next, _):
+        return next <= current and next != 0
+
+    def cond2(self, current, next, max):
+        return (next - current) != 1 and (current != next) and not (next == 0 and current == max)
+
+    def cond3(self, current, next, _):
+        return abs(current - next) > 1
+
+    def cond4(self, current, next, max):
+        return not (
+            (abs(current - next) <= 1) or
+            (current == max and next == 0) or
+            (current == 0 and next == max)
+        )
+
+    def cond5(self, _, next, __):
+        return (next % 2)
+
+    def cond6(self, current, next, _):
+        return next == current
+
+def restrict(self, design_space=None, condition=lambda current, next: current > next, name="Restrict"):
+    if design_space is None:
+        design_space = self.design_space
+        pass
+
+    original_size = design_space.size
+    options = 0
+    removed = 0
+    for hole in design_space:
+        assert re.match(
+            r"[AM]\(\[.*],\d\)", hole.name), "Cannot use restrict function, hole name doesn't match"
+
+        if hole.name[0] == "M":
+            current = int(hole.name[-2])
+            max = sorted(hole.options)[-2]
+            for option in hole.options.copy():
+                options += 1
+                if condition(current, option, max):
+                    hole.options.remove(option)
+                    removed += 1
+
+    if design_space.size:
+        print("[{}]\tReduced to {}%".format(
+            name.upper(),
+            format((design_space.size/original_size)*100, ".10f")
+        ), "of original size")
+
+    if options:
+        print("[{}]\tRemoved {}%".format(
+            name.upper(),
+            format((removed/options)*100, ".10f")
+        ), "of options")
+    return design_space


### PR DESCRIPTION
In `restriction_conditions.py` I've experimented with five ways to reduce the design_space and allow for faster synthesis.

### Example:
Run with:
```
python3 paynt/paynt.py --project workspace/examples/pomdp/grid/simple ar --pomdp
```

#### Original:
![original](https://user-images.githubusercontent.com/19515281/157442221-bbb1e603-3306-462b-a549-7296c6421ca8.png)

#### After reducing the design space to ~0.025% of its original size:
![circular_one_way](https://user-images.githubusercontent.com/19515281/157443371-a2516eda-a6c7-4da0-a374-b909d8790b20.png)

#### The final controller:
![run_circular_one_way](https://user-images.githubusercontent.com/19515281/157443436-41b7d2b9-6d2e-489a-8803-0fedaf6574b8.png)

 **Note:** the `Run with restrictions` commit is only included to allow for easy experimenting with design space restrictions. It does depend on the [Graphs module](https://github.com/randriu/synthesis/pull/6) and can be removed at any time.