### PR TITLE
Added support for discounted properties

### DIFF
--- a/models/pomdp/maze/discount/sketch.props
+++ b/models/pomdp/maze/discount/sketch.props
@@ -1,0 +1,2 @@
+//R{"steps"}min=? [F goal]
+R{"steps"}min=? [C{0.99}]

--- a/models/pomdp/maze/discount/sketch.templ
+++ b/models/pomdp/maze/discount/sketch.templ
@@ -1,0 +1,91 @@
+pomdp
+
+// 3 | x x x x x
+// 2 | x   x   x
+// 1 | x   x   x
+// 0 | x   x   x
+// y ____________
+//   x 0 1 2 3 4
+
+// can go in this direction
+formula u = y<3;
+formula r = y=3 & x<4;
+formula d = y>0 & (x=0 | x=2 | x=4);
+formula l = y=3 & x>0;
+
+// target cell
+formula goal = x=2 & y=0;
+formula bad = (x=0 | x=4) & y=0;
+
+// updates of coordinates (if possible)
+formula yu = u ? (y+1) : y;
+formula xr = r ? (x+1) : x;
+formula yd = d ? (y-1) : y;
+formula xl = l ? (x-1) : x;
+
+// corresponding observables
+observable "u" = clk=1 & u;
+observable "r" = clk=1 & r;
+observable "d" = clk=1 & d;
+observable "l" = clk=1 & l;
+observable "goal" = goal;
+observable "bad" = bad;
+
+
+// modules
+
+module clock
+    // 0 - init, 1 - drive
+    clk : [0..1] init 0;
+
+    // random placement
+    [place] clk=0 -> (clk'=1);
+    
+    // drive
+    [up] 	clk=1 -> true;
+    [right] clk=1 -> true;
+    [down] 	clk=1 -> true;
+    [left]  clk=1 -> true;
+endmodule
+
+module maze
+
+	x : [0..4] init 0;
+    y : [0..3] init 0;
+	
+	// initialisation
+	[place] true ->
+          1/13 :    (x'=0)&(y'=0)
+        + 1/13 :    (x'=0)&(y'=1)
+		+ 1/13 :    (x'=0)&(y'=2)
+		+ 1/13 :    (x'=0)&(y'=3)
+		+ 1/13 :    (x'=1)&(y'=3)
+		+ 1/13 :    (x'=2)&(y'=0)
+		+ 1/13 :    (x'=2)&(y'=1)
+		+ 1/13 :    (x'=2)&(y'=2)
+		+ 1/13 :    (x'=2)&(y'=3)
+		+ 1/13 :    (x'=3)&(y'=3)
+		+ 1/13 :    (x'=4)&(y'=1)
+		+ 1/13 :    (x'=4)&(y'=2)
+		+ 1/13 :    (x'=4)&(y'=3);
+
+	// moving around the maze (all combinations)
+    
+    [up]        !goal -> 0.8: (y'=yu) + 0.08: (x'=xr) + 0.08: (x'=xl) + 0.04: (y'=yd);
+    [right]     !goal -> 0.8: (x'=xr) + 0.08: (y'=yu) + 0.08: (y'=yd) + 0.04: (x'=xl);
+    [down]      !goal -> 0.8: (y'=yd) + 0.08: (x'=xr) + 0.08: (x'=xl) + 0.04: (y'=yu);
+    [left]      !goal -> 0.8: (x'=xl) + 0.08: (y'=yu) + 0.08: (y'=yd) + 0.04: (x'=xr);
+
+    [up]        goal -> true;
+    [right]     goal -> true;
+    [down]      goal -> true;
+    [left]      goal -> true;
+	
+endmodule
+
+// rewards
+
+rewards "steps"
+	clk=1 & !goal: 1;
+endrewards
+

--- a/payntbind/src/synthesis/helpers.cpp
+++ b/payntbind/src/synthesis/helpers.cpp
@@ -13,6 +13,8 @@
 #include <storm/environment/solver/MinMaxSolverEnvironment.h>
 #include <storm/storage/SparseMatrix.h>
 #include <storm/models/sparse/Model.h>
+#include <storm/models/sparse/Dtmc.h>
+#include <storm/storage/sparse/ModelComponents.h>
 
 namespace synthesis {
 
@@ -42,6 +44,53 @@ void removeRewardModel(storm::models::sparse::Model<ValueType> & model, std::str
     model.removeRewardModel(reward_name);
 }
 
+template<typename ValueType>
+std::shared_ptr<storm::models::sparse::Dtmc<ValueType>> applyDiscountTransformationToDtmc(storm::models::sparse::Dtmc<ValueType> &model, double discount_factor) {
+    storm::storage::sparse::ModelComponents<ValueType> components;
+
+    auto dtmcNumberOfStates = model.getNumberOfStates();
+
+    // labeling
+    storm::models::sparse::StateLabeling stateLabeling(dtmcNumberOfStates+1);
+    storm::storage::BitVector init_flags = model.getInitialStates();
+    init_flags.resize(dtmcNumberOfStates+1, false);
+    stateLabeling.addLabel("init", std::move(init_flags));
+    storm::storage::BitVector discount_flag(dtmcNumberOfStates+1, false);
+    discount_flag.set(dtmcNumberOfStates, true);
+    stateLabeling.addLabel("discount_sink", std::move(discount_flag));
+    components.stateLabeling = stateLabeling;
+
+    // transition matrix
+    storm::storage::SparseMatrix<ValueType> const& transitionMatrix = model.getTransitionMatrix();
+    storm::storage::SparseMatrixBuilder<ValueType> builder;
+    for (uint_fast64_t state = 0; state < dtmcNumberOfStates; state++) {
+        // this function was created for cassandra models where we don't want to discount the first transition
+        // maybe it's not needed? TODO
+        if (state == 0) {
+            for (auto entry: transitionMatrix.getRow(state)) {
+                builder.addNextValue(state, entry.getColumn(), entry.getValue());
+            }
+            builder.addNextValue(state, dtmcNumberOfStates, 0);
+        }
+        else {
+            for (auto entry: transitionMatrix.getRow(state)) {
+                builder.addNextValue(state, entry.getColumn(), entry.getValue() * discount_factor);
+            }
+            builder.addNextValue(state, dtmcNumberOfStates, 1-discount_factor);
+        }
+    }
+    for (uint_fast64_t state = 0; state < dtmcNumberOfStates; state++) {
+        builder.addNextValue(dtmcNumberOfStates, state, 0);
+    }
+    builder.addNextValue(dtmcNumberOfStates, dtmcNumberOfStates, 1);
+    components.transitionMatrix = builder.build();
+
+    // reward model
+    //components.rewardModels.emplace(this->reward_model_name, this->constructRewardModel());
+
+    return std::make_shared<storm::models::sparse::Dtmc<ValueType>>(std::move(components));
+}
+
 }
 
 
@@ -58,6 +107,8 @@ void define_helpers(py::module& m) {
 
     m.def("transform_until_to_eventually", &synthesis::transformUntilToEventually<double>, py::arg("formula"));
     m.def("remove_reward_model", &synthesis::removeRewardModel<double>, py::arg("model"), py::arg("reward_name"));
+
+    m.def("apply_discount_transformation_to_dtmc", &synthesis::applyDiscountTransformationToDtmc<double>, py::arg("model"), py::arg("discount_factor"));
 
     m.def("multiply_with_vector", [] (storm::storage::SparseMatrix<double> matrix,std::vector<double> vector) {
         std::vector<double> result(matrix.getRowCount());


### PR DESCRIPTION
Support for discounted properties in PAYNT, namely the computation of discounted expected visits.
Also added a maze POMDP with a discounted property as an example.

This still depends on the Storm implementation of discounted VI and, therefore doesn't work on the current master of Storm/StormPy.