### PR TITLE
Fix build issues described in #47

### DIFF
--- a/payntbind/CMakeLists.txt
+++ b/payntbind/CMakeLists.txt
@@ -21,7 +21,7 @@ include(resources/include_pybind11.cmake)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros.cmake)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # This sets interprocedural optimization off as this leads to some problems on some systems
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)

--- a/payntbind/src/synthesis/quotient/ColoringSmt.cpp
+++ b/payntbind/src/synthesis/quotient/ColoringSmt.cpp
@@ -514,7 +514,7 @@ std::pair<bool,std::vector<std::vector<uint64_t>>> ColoringSmt<ValueType>::areCh
     }
     STORM_LOG_THROW(harmonizing_hole_found, storm::exceptions::UnexpectedException, "harmonized UNSAT core is not SAT");*/
 
-    solver.add(0 <= harmonizing_variable and harmonizing_variable < family.numHoles(), "harmonizing_domain");
+    solver.add(0 <= harmonizing_variable and harmonizing_variable < (int)family.numHoles(), "harmonizing_domain");
     consistent = check();
     STORM_LOG_THROW(consistent, storm::exceptions::UnexpectedException, "harmonized UNSAT core is not SAT");
     model = solver.get_model();


### PR DESCRIPTION
This fixes the following build issues from #47:
- C++20 instead of C++17
- convert `family.numHoles()` to `int`