### PR TITLE
Add synthesis for exact POMDPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ prerequisites/
 
 # OSX
 .DS_Store
+
+build/

--- a/paynt/cli.py
+++ b/paynt/cli.py
@@ -32,7 +32,7 @@ def setup_logger(log_path = None):
     # root.setLevel(logging.INFO)
 
     # formatter = logging.Formatter('%(asctime)s %(threadName)s - %(name)s - %(levelname)s - %(message)s')
-    formatter = logging.Formatter('%(asctime)s - %(filename)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(filename)s:%(lineno)d - %(message)s')
 
     handlers = []
     if log_path is not None:
@@ -61,6 +61,8 @@ def setup_logger(log_path = None):
     help="known optimum bound")
 @click.option("--precision", type=click.FLOAT, default=1e-4,
     help="model checking precision")
+@click.option("--exact", is_flag=True, default=False,
+    help="use exact synthesis (very limited at the moment)")
 @click.option("--timeout", type=int,
     help="timeout (s)")
 
@@ -138,7 +140,7 @@ def setup_logger(log_path = None):
     help="run profiling")
 
 def paynt_run(
-    project, sketch, props, relative_error, optimum_threshold, precision, timeout,
+    project, sketch, props, relative_error, optimum_threshold, precision, exact, timeout,
     export,
     method,
     disable_expected_visits,
@@ -187,7 +189,7 @@ def paynt_run(
 
     sketch_path = os.path.join(project, sketch)
     properties_path = os.path.join(project, props)
-    quotient = paynt.parser.sketch.Sketch.load_sketch(sketch_path, properties_path, export, relative_error, precision, constraint_bound)
+    quotient = paynt.parser.sketch.Sketch.load_sketch(sketch_path, properties_path, export, relative_error, precision, constraint_bound, exact)
     synthesizer = paynt.synthesizer.synthesizer.Synthesizer.choose_synthesizer(quotient, method, fsc_synthesis, storm_control)
     synthesizer.run(optimum_threshold)
 

--- a/paynt/family/__init__.py
+++ b/paynt/family/__init__.py
@@ -1,0 +1,10 @@
+__version__ = "unknown"
+
+try:
+    from .._version import __version__
+except ImportError:
+    # We're running in a tree that doesn't have a _version.py, so we don't know what our version is.
+    pass
+
+def version():
+    return __version__

--- a/paynt/models/__init__.py
+++ b/paynt/models/__init__.py
@@ -1,0 +1,10 @@
+__version__ = "unknown"
+
+try:
+    from .._version import __version__
+except ImportError:
+    # We're running in a tree that doesn't have a _version.py, so we don't know what our version is.
+    pass
+
+def version():
+    return __version__

--- a/paynt/models/model_builder.py
+++ b/paynt/models/model_builder.py
@@ -29,12 +29,15 @@ class ModelBuilder:
         return model
 
     @classmethod
-    def from_prism(cls, program, specification = None):
+    def from_prism(cls, program, specification = None, use_exact=False):
         assert program.model_type in [stormpy.storage.PrismModelType.MDP, stormpy.storage.PrismModelType.POMDP]
         builder_options = cls.default_builder_options(specification)
-        model = stormpy.build_sparse_model_with_options(program, builder_options)
+        if use_exact:
+            model = stormpy.build_sparse_exact_model_with_options(program, builder_options)
+        else:
+            model = stormpy.build_sparse_model_with_options(program, builder_options)
         return model
 
     @classmethod
-    def from_drn(cls, drn_path):
-        return DrnParser.parse_drn(drn_path)
+    def from_drn(cls, drn_path, use_exact=False):
+        return DrnParser.parse_drn(drn_path, use_exact)

--- a/paynt/parser/drn_parser.py
+++ b/paynt/parser/drn_parser.py
@@ -1,4 +1,3 @@
-from matplotlib import use
 import stormpy
 import payntbind
 

--- a/paynt/parser/drn_parser.py
+++ b/paynt/parser/drn_parser.py
@@ -1,3 +1,4 @@
+from matplotlib import use
 import stormpy
 import payntbind
 
@@ -17,20 +18,22 @@ class DrnParser:
     WHITESPACES = ' \t\n\v\f\r'
 
     @classmethod
-    def parse_drn(cls, sketch_path):
+    def parse_drn(cls, sketch_path, use_exact=False):
         # try to read a drn file and return POSMG or POMDP based on the type
         # ValueError if file is not dnr or the model is of unsupported type
         explicit_model = None
         try:
             type = DrnParser.decide_type_of_drn(sketch_path)
             if type == 'POSMG':
+                if use_exact:
+                    raise ValueError('Exact synthesis is not supported for POSMG models')
                 pomdp_path = sketch_path + '.tmp'
                 state_player_indications = DrnParser.pomdp_from_posmg(sketch_path, pomdp_path)
                 pomdp = DrnParser.read_drn(pomdp_path)
                 explicit_model = payntbind.synthesis.posmg_from_pomdp(pomdp, state_player_indications)
                 os.remove(pomdp_path)
             else:
-                explicit_model = DrnParser.read_drn(sketch_path)
+                explicit_model = DrnParser.read_drn(sketch_path, use_exact)
         except Exception as e:
             print(e)
             raise ValueError('Failed to read sketch file in a .drn format')
@@ -91,10 +94,13 @@ class DrnParser:
         return string[:start_idx] + string[end_idx+1:]
 
     @classmethod
-    def read_drn(cls, sketch_path):
+    def read_drn(cls, sketch_path, use_exact=False):
         builder_options = stormpy.core.DirectEncodingParserOptions()
         builder_options.build_choice_labels = True
-        return stormpy.build_model_from_drn(sketch_path, builder_options)
+        if use_exact:
+            return stormpy.core._build_sparse_exact_model_from_drn(sketch_path, builder_options)
+        else:
+            return stormpy.build_model_from_drn(sketch_path, builder_options)
 
     @staticmethod
     def parse_posmg_specification(properties_path):

--- a/paynt/parser/prism_parser.py
+++ b/paynt/parser/prism_parser.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class PrismParser:
 
     @classmethod
-    def read_prism(cls, sketch_path, properties_path, relative_error):
+    def read_prism(cls, sketch_path, properties_path, relative_error, use_exact=False):
 
         # parse the program
         prism, hole_definitions = PrismParser.load_sketch_prism(sketch_path)
@@ -41,7 +41,7 @@ class PrismParser:
             prism, hole_expressions, family = PrismParser.parse_holes(prism, expression_parser, hole_definitions)
         prism = prism.label_unlabelled_commands({})
 
-        specification = PrismParser.parse_specification(properties_path, relative_error, prism)
+        specification = PrismParser.parse_specification(properties_path, relative_error, prism, use_exact=use_exact)
 
         # construct the quotient
         coloring = None
@@ -58,7 +58,7 @@ class PrismParser:
                 obs_evaluator = payntbind.synthesis.ObservationEvaluator(prism, quotient_mdp)
             quotient_mdp = payntbind.synthesis.addChoiceLabelsFromJani(quotient_mdp)
         else:
-            quotient_mdp = paynt.models.model_builder.ModelBuilder.from_prism(prism, specification)
+            quotient_mdp = paynt.models.model_builder.ModelBuilder.from_prism(prism, specification, use_exact)
 
         return prism, quotient_mdp, specification, family, coloring, jani_unfolder, obs_evaluator
 
@@ -192,7 +192,7 @@ class PrismParser:
         return props[0]
 
     @classmethod
-    def parse_specification(cls, properties_path, relative_error=0, prism=None):
+    def parse_specification(cls, properties_path, relative_error=0, prism=None, use_exact=False):
         '''
         Expecting one property per line. The line may be terminated with a semicolon.
         Empty lines or comments are allowed.
@@ -211,7 +211,7 @@ class PrismParser:
             formula = PrismParser.parse_property(line,prism)
             if formula is None:
                 continue
-            prop = paynt.verification.property.construct_property(formula, relative_error)
+            prop = paynt.verification.property.construct_property(formula, relative_error, use_exact)
             properties.append(prop)
 
         specification = paynt.verification.property.Specification(properties)

--- a/paynt/parser/sketch.py
+++ b/paynt/parser/sketch.py
@@ -48,15 +48,20 @@ def make_rewards_action_based(model):
             for action in range(tm.get_row_group_start(state),tm.get_row_group_end(state)):
                 action_reward[action] += state_reward
 
-        payntbind.synthesis.remove_reward_model(model,name)
-        new_reward_model = stormpy.storage.SparseRewardModel(optional_state_action_reward_vector=action_reward)
-        model.add_reward_model(name, new_reward_model)
+        if model.is_exact:
+            payntbind.synthesis.remove_reward_model_exact(model,name)
+            new_reward_model = stormpy.storage.SparseExactRewardModel(optional_state_action_reward_vector=action_reward)
+            model.add_reward_model(name, new_reward_model)
+        else:
+            payntbind.synthesis.remove_reward_model(model,name)
+            new_reward_model = stormpy.storage.SparseRewardModel(optional_state_action_reward_vector=action_reward)
+            model.add_reward_model(name, new_reward_model)
 
 class Sketch:
 
     @classmethod
     def load_sketch(cls, sketch_path, properties_path,
-        export=None, relative_error=0, precision=1e-4, constraint_bound=None):
+        export=None, relative_error=0, precision=1e-4, constraint_bound=None, use_exact=False):
 
         prism = None
         explicit_quotient = None
@@ -78,15 +83,15 @@ class Sketch:
         try:
             logger.info(f"assuming sketch in PRISM format...")
             prism, explicit_quotient, specification, family, coloring, jani_unfolder, obs_evaluator = PrismParser.read_prism(
-                        sketch_path, properties_path, relative_error)
+                        sketch_path, properties_path, relative_error, use_exact)
             filetype = "prism"
         except SyntaxError:
             pass
         if filetype is None:
             try:
                 logger.info(f"assuming sketch in DRN format...")
-                explicit_quotient = paynt.models.model_builder.ModelBuilder.from_drn(sketch_path)
-                specification = PrismParser.parse_specification(properties_path, relative_error)
+                explicit_quotient = paynt.models.model_builder.ModelBuilder.from_drn(sketch_path, use_exact)
+                specification = PrismParser.parse_specification(properties_path, relative_error, use_exact=use_exact)
                 filetype = "drn"
                 project_path = os.path.dirname(sketch_path)
                 valuations_filename = "state-valuations.json"
@@ -96,6 +101,8 @@ class Sketch:
                     with open(valuations_path) as file:
                         state_valuations = json.load(file)
                 if state_valuations is not None:
+                    if use_exact:
+                        raise Exception("exact synthesis is not supported with state valuations")
                     logger.info(f"found state valuations in {valuations_path}, adding to the model...")
                     explicit_quotient = payntbind.synthesis.addStateValuations(explicit_quotient,state_valuations)
             except Exception as e:
@@ -125,10 +132,14 @@ class Sketch:
                 pass
 
         assert filetype is not None, "unknown format of input file"
+        logger.info(str(explicit_quotient))
         logger.info("sketch parsing OK")
 
         paynt.verification.property.Property.initialize()
-        updated = payntbind.synthesis.addMissingChoiceLabels(explicit_quotient)
+        if explicit_quotient.is_exact:
+            updated = payntbind.synthesis.addMissingChoiceLabelsExact(explicit_quotient)
+        else:
+            updated = payntbind.synthesis.addMissingChoiceLabels(explicit_quotient)
         if updated is not None: explicit_quotient = updated
         if not payntbind.synthesis.assertChoiceLabelingIsCanonic(explicit_quotient.nondeterministic_choice_indices,explicit_quotient.choice_labeling,False):
             logger.warning("WARNING: choice labeling for the quotient is not canonic")

--- a/paynt/parser/sketch.py
+++ b/paynt/parser/sketch.py
@@ -132,7 +132,6 @@ class Sketch:
                 pass
 
         assert filetype is not None, "unknown format of input file"
-        logger.info(str(explicit_quotient))
         logger.info("sketch parsing OK")
 
         paynt.verification.property.Property.initialize()

--- a/paynt/quotient/pomdp.py
+++ b/paynt/quotient/pomdp.py
@@ -63,7 +63,7 @@ class PomdpQuotient(paynt.quotient.quotient.Quotient):
         # ^ this also asserts that states with the same observation have the
         # same number and the same order of available actions
 
-        logger.info(f"constructed {'Exact' if self.pomdp.is_exact else ''} POMDP having {self.observations} observations.")
+        logger.info(f"constructed {'exact' if self.pomdp.is_exact else ''} POMDP having {self.observations} observations.")
 
         state_obs = self.pomdp.observations.copy()
 

--- a/paynt/quotient/quotient.py
+++ b/paynt/quotient/quotient.py
@@ -89,9 +89,14 @@ class Quotient:
         tm = mdp.transition_matrix
         tm.make_row_grouping_trivial()
         assert tm.nr_columns == tm.nr_rows, "expected transition matrix without non-trivial row groups"
-        components = stormpy.storage.SparseModelComponents(tm, mdp.labeling, mdp.reward_models)
-        dtmc = stormpy.storage.SparseDtmc(components)
-        return dtmc
+        if mdp.is_exact:
+            components = stormpy.storage.SparseExactModelComponents(tm, mdp.labeling, mdp.reward_models)
+            dtmc = stormpy.storage.SparseExactDtmc(components)
+            return dtmc
+        else:
+            components = stormpy.storage.SparseModelComponents(tm, mdp.labeling, mdp.reward_models)
+            dtmc = stormpy.storage.SparseDtmc(components)
+            return dtmc
 
     def build_assignment(self, family):
         assert family.size == 1, "expecting family of size 1"
@@ -120,7 +125,10 @@ class Quotient:
         return state_to_choice_reachable
 
     def scheduler_to_state_to_choice(self, submdp, scheduler, discard_unreachable_choices=True):
-        state_to_quotient_choice = payntbind.synthesis.schedulerToStateToGlobalChoice(scheduler, submdp.model, submdp.quotient_choice_map)
+        if submdp.model.is_exact:
+            state_to_quotient_choice = payntbind.synthesis.schedulerToStateToGlobalChoiceExact(scheduler, submdp.model, submdp.quotient_choice_map)
+        else:
+            state_to_quotient_choice = payntbind.synthesis.schedulerToStateToGlobalChoice(scheduler, submdp.model, submdp.quotient_choice_map)
         state_to_choice = self.empty_scheduler()
         for state in range(submdp.model.nr_states):
             quotient_choice = state_to_quotient_choice[state]
@@ -158,7 +166,10 @@ class Quotient:
         '''
 
         # multiply probability with model checking results
-        choice_values = payntbind.synthesis.multiply_with_vector(mdp.transition_matrix, state_values)
+        if mdp.is_exact:
+            choice_values = payntbind.synthesis.multiply_with_vector_exact(mdp.transition_matrix, state_values)
+        else:
+            choice_values = payntbind.synthesis.multiply_with_vector(mdp.transition_matrix, state_values)
         choice_values = Quotient.make_vector_defined(choice_values)
 
         # if the associated reward model has state-action rewards, then these must be added to choice values

--- a/paynt/synthesizer/statistic.py
+++ b/paynt/synthesizer/statistic.py
@@ -74,9 +74,9 @@ class Statistic:
         ''' Identify the type of the model and count corresponding iteration. '''
         if isinstance(model, paynt.models.models.Mdp):
             model = model.model
-        if type(model) == stormpy.storage.SparseDtmc:
+        if type(model) == stormpy.storage.SparseDtmc or type(model) == stormpy.storage.SparseExactDtmc:
             self.iteration_dtmc(model.nr_states)
-        elif type(model) == stormpy.storage.SparseMdp:
+        elif type(model) == stormpy.storage.SparseMdp or type(model) == stormpy.storage.SparseExactMdp:
             self.iteration_mdp(model.nr_states)
         else:
             logger.debug(f"unknown model type {type(model)}")
@@ -150,7 +150,9 @@ class Statistic:
             if opt is None:
                 opt = spec.optimality.optimum
             if opt is not None:
-                ret_str += f", opt = {round(opt,4)}"
+                if not isinstance(opt, stormpy.Rational):
+                    opt = round(opt, 4)
+                ret_str += f", opt = {opt}"
         return ret_str
 
 
@@ -202,7 +204,10 @@ class Statistic:
     def get_summary_synthesis(self):
         spec = self.quotient.specification
         if spec.has_optimality and spec.optimality.optimum is not None:
-            optimum = round(spec.optimality.optimum, 6)
+            if isinstance(spec.optimality.optimum, stormpy.Rational):
+                optimum = spec.optimality.optimum
+            else:
+                optimum = round(spec.optimality.optimum, 6)
             return f"optimum: {optimum}"
         else:
             feasible = "yes" if self.synthesized_assignment is not None else "no"

--- a/paynt/synthesizer/statistic.py
+++ b/paynt/synthesizer/statistic.py
@@ -74,9 +74,9 @@ class Statistic:
         ''' Identify the type of the model and count corresponding iteration. '''
         if isinstance(model, paynt.models.models.Mdp):
             model = model.model
-        if type(model) == stormpy.storage.SparseDtmc or type(model) == stormpy.storage.SparseExactDtmc:
+        if type(model) in [stormpy.storage.SparseDtmc, stormpy.storage.SparseExactDtmc]:
             self.iteration_dtmc(model.nr_states)
-        elif type(model) == stormpy.storage.SparseMdp or type(model) == stormpy.storage.SparseExactMdp:
+        elif type(model) in [stormpy.storage.SparseMdp, stormpy.storage.SparseExactMdp]:
             self.iteration_mdp(model.nr_states)
         else:
             logger.debug(f"unknown model type {type(model)}")

--- a/paynt/verification/property.py
+++ b/paynt/verification/property.py
@@ -76,11 +76,11 @@ class Property:
         # se.set_linear_equation_solver_type(stormpy.EquationSolverType.gmmxx)
         se.set_linear_equation_solver_type(stormpy.EquationSolverType.eigen)
 
-        se.minmax_solver_environment.method = stormpy.MinMaxMethod.policy_iteration
+        # se.minmax_solver_environment.method = stormpy.MinMaxMethod.policy_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.sound_value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.interval_iteration
-        # se.minmax_solver_environment.method = stormpy.MinMaxMethod.optimistic_value_iteration
+        se.minmax_solver_environment.method = stormpy.MinMaxMethod.optimistic_value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.topological
 
     @classmethod

--- a/paynt/verification/property.py
+++ b/paynt/verification/property.py
@@ -7,10 +7,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def construct_property(prop, relative_error):
+def construct_property(prop, relative_error, use_exact=False):
     rf = prop.raw_formula
     player_index = None
+    if rf.is_reward_operator and use_exact:
+        raise ValueError("exact synthesis is not supported for reward properties")
+    
     if not (rf.is_reward_operator or rf.is_probability_operator) and rf.is_game_formula:
+        if use_exact:
+            raise ValueError("exact synthesis is not supported for game properties")
+        
         player_index = extract_player_index(rf)
         game_rf = rf
         rf = rf.subformula
@@ -18,9 +24,9 @@ def construct_property(prop, relative_error):
     assert rf.has_bound != rf.has_optimality_type, \
         "optimizing formula contains a bound or a comparison formula does not"
     if rf.has_bound:
-        prop = Property(prop)
+        prop = Property(prop, use_exact)
     else:
-        prop = OptimalityProperty(prop, relative_error)
+        prop = OptimalityProperty(prop, relative_error, use_exact)
 
     if player_index is not None:
         prop.game_optimizing_player = player_index
@@ -52,7 +58,7 @@ class Property:
     # model checking environment (method & precision)
     environment = None
     # model checking precision
-    model_checking_precision = 1e-4
+    model_checking_precision = 1e-6
 
     @classmethod
     def set_model_checking_precision(cls, precision):
@@ -66,15 +72,15 @@ class Property:
         cls.set_model_checking_precision(cls.model_checking_precision)
 
         se = cls.environment.solver_environment
-        se.set_linear_equation_solver_type(stormpy.EquationSolverType.native)
+        # se.set_linear_equation_solver_type(stormpy.EquationSolverType.native)
         # se.set_linear_equation_solver_type(stormpy.EquationSolverType.gmmxx)
-        # se.set_linear_equation_solver_type(stormpy.EquationSolverType.eigen)
+        se.set_linear_equation_solver_type(stormpy.EquationSolverType.eigen)
 
-        # se.minmax_solver_environment.method = stormpy.MinMaxMethod.policy_iteration
+        se.minmax_solver_environment.method = stormpy.MinMaxMethod.policy_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.sound_value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.interval_iteration
-        se.minmax_solver_environment.method = stormpy.MinMaxMethod.optimistic_value_iteration
+        # se.minmax_solver_environment.method = stormpy.MinMaxMethod.optimistic_value_iteration
         # se.minmax_solver_environment.method = stormpy.MinMaxMethod.topological
 
     @classmethod
@@ -89,15 +95,19 @@ class Property:
 
     @staticmethod
     def above_model_checking_precision(a, b):
+        if isinstance(a, stormpy.Rational):
+            return True
         return abs(a-b) > Property.model_checking_precision
 
 
-    def __init__(self, prop):
+    def __init__(self, prop, use_exact=False):
         self.property = prop
         rf = prop.raw_formula
 
         self.game_optimizing_player = None # player index for game properties
         self.game_formula = None
+
+        self.use_exact = use_exact
 
         # use comparison type to deduce optimizing direction
         comparison_type = rf.comparison_type
@@ -110,11 +120,15 @@ class Property:
         }[comparison_type]
 
         # set threshold
-        self.threshold = rf.threshold_expr.evaluate_as_double()
-        if self.minimizing:
-            self.threshold_plus_precision = self.threshold + Property.model_checking_precision
+        if use_exact:
+            self.threshold = rf.threshold_expr.evaluate_as_rational()
+            self.threshold_plus_precision = self.threshold
         else:
-            self.threshold_plus_precision = self.threshold - Property.model_checking_precision
+            self.threshold = rf.threshold_expr.evaluate_as_double()
+            if self.minimizing:
+                self.threshold_plus_precision = self.threshold + Property.model_checking_precision
+            else:
+                self.threshold_plus_precision = self.threshold - Property.model_checking_precision
 
         # construct quantitative formula (without bound) for explicit model checking
         # set optimality type
@@ -171,7 +185,7 @@ class Property:
         logger.info("converting until formula to eventually...")
         formula = payntbind.synthesis.transform_until_to_eventually(self.property.raw_formula)
         prop = stormpy.core.Property("", formula)
-        self.__init__(prop)
+        self.__init__(prop, self.use_exact)
 
     def property_copy(self):
         return stormpy.core.Property("", self.property.raw_formula.clone())
@@ -240,12 +254,14 @@ class OptimalityProperty(Property):
     Optimality property can remember current optimal value and adapt the
     corresponding threshold wrt epsilon.
     '''
-    def __init__(self, prop, epsilon=0):
+    def __init__(self, prop, epsilon=0, use_exact=False):
         self.property = prop
         rf = prop.raw_formula
 
         self.game_optimizing_player = None # player index for game properties
         self.game_formula = None
+
+        self.use_exact = use_exact
 
         # use comparison type to deduce optimizing direction
         if rf.optimality_type == stormpy.OptimizationDirection.Minimize:
@@ -261,7 +277,10 @@ class OptimalityProperty(Property):
 
         # additional optimality stuff
         self.optimum = None
-        self.epsilon = epsilon
+        if use_exact:
+            self.epsilon = stormpy.Rational(epsilon)
+        else:
+            self.epsilon = epsilon
 
         self.reset()
 
@@ -276,9 +295,15 @@ class OptimalityProperty(Property):
     def reset(self):
         self.optimum = None
         if self.minimizing:
-            self.threshold = math.inf
+            if self.use_exact:
+                self.threshold = stormpy.Rational(2) # TODO: does not work for rewards
+            else:
+                self.threshold = math.inf
         else:
-            self.threshold = -math.inf
+            if self.use_exact:
+                self.threshold = stormpy.Rational(-1) # TODO: does not work for rewards
+            else:
+                self.threshold = -math.inf
 
     def meets_op(self, a, b):
         ''' For optimality objective, we want to accept improvements above model checking precision. '''
@@ -310,7 +335,7 @@ class OptimalityProperty(Property):
         logger.info("converting until formula to eventually...")
         formula = payntbind.synthesis.transform_until_to_eventually(self.property.raw_formula)
         prop = stormpy.core.Property("", formula)
-        self.__init__(prop, self.epsilon)
+        self.__init__(prop, self.epsilon, self.use_exact)
 
     @property
     def can_be_improved(self):

--- a/paynt/verification/property.py
+++ b/paynt/verification/property.py
@@ -58,7 +58,7 @@ class Property:
     # model checking environment (method & precision)
     environment = None
     # model checking precision
-    model_checking_precision = 1e-6
+    model_checking_precision = 1e-4
 
     @classmethod
     def set_model_checking_precision(cls, precision):

--- a/payntbind/.gitignore
+++ b/payntbind/.gitignore
@@ -13,3 +13,4 @@ _build/
 cmake-build-debug/
 
 .DS_Store
+.cache/

--- a/payntbind/src/synthesis/helpers.cpp
+++ b/payntbind/src/synthesis/helpers.cpp
@@ -1,5 +1,6 @@
 #include "synthesis.h"
 
+#include <storm/adapters/RationalNumberAdapter.h>
 #include <storm/logic/Formula.h>
 #include <storm/logic/UntilFormula.h>
 #include <storm/logic/OperatorFormula.h>
@@ -70,9 +71,16 @@ void define_helpers(py::module& m) {
 
     m.def("transform_until_to_eventually", &synthesis::transformUntilToEventually<double>, py::arg("formula"));
     m.def("remove_reward_model", &synthesis::removeRewardModel<double>, py::arg("model"), py::arg("reward_name"));
+    m.def("remove_reward_model_exact", &synthesis::removeRewardModel<storm::RationalNumber>, py::arg("model"), py::arg("reward_name"));
 
     m.def("multiply_with_vector", [] (storm::storage::SparseMatrix<double> matrix,std::vector<double> vector) {
         std::vector<double> result(matrix.getRowCount());
+        matrix.multiplyWithVector(vector, result);
+        return result;
+    }, py::arg("matrix"), py::arg("vector"));
+
+    m.def("multiply_with_vector_exact", [] (storm::storage::SparseMatrix<storm::RationalNumber> matrix,std::vector<storm::RationalNumber> vector) {
+        std::vector<storm::RationalNumber> result(matrix.getRowCount());
         matrix.multiplyWithVector(vector, result);
         return result;
     }, py::arg("matrix"), py::arg("vector"));

--- a/payntbind/src/synthesis/pomdp/PomdpManager.cpp
+++ b/payntbind/src/synthesis/pomdp/PomdpManager.cpp
@@ -5,6 +5,7 @@
 #include "storm/storage/sparse/ModelComponents.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/adapters/RationalNumberAdapter.h"
 
 namespace synthesis {
    
@@ -314,5 +315,6 @@ void PomdpManager<ValueType>::setGlobalMemorySize(uint64_t memory_size) {
 
 
 template class PomdpManager<double>;
+template class PomdpManager<storm::RationalNumber>;
 
 }

--- a/payntbind/src/synthesis/pomdp/PomdpManagerAposteriori.cpp
+++ b/payntbind/src/synthesis/pomdp/PomdpManagerAposteriori.cpp
@@ -5,6 +5,7 @@
 #include "storm/storage/sparse/ModelComponents.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/adapters/RationalNumberAdapter.h"
 
 namespace synthesis {
         
@@ -257,4 +258,5 @@ namespace synthesis {
     }
 
     template class PomdpManagerAposteriori<double>;
+    template class PomdpManagerAposteriori<storm::RationalNumber>;
 }

--- a/payntbind/src/synthesis/pomdp/bindings.cpp
+++ b/payntbind/src/synthesis/pomdp/bindings.cpp
@@ -2,42 +2,49 @@
 
 #include "PomdpManager.h"
 #include "PomdpManagerAposteriori.h"
+#include <storm/adapters/RationalNumberAdapter.h>
+#include <string>
 
-void bindings_pomdp(py::module& m) {
+template<typename ValueType>
+void bindings_pomdp_vt(py::module& m, std::string const& vtSuffix) {
 
-    py::class_<synthesis::PomdpManager<double>>(m, "PomdpManager", "POMDP manager")
-        .def(py::init<storm::models::sparse::Pomdp<double> const&>(), "Constructor.", py::arg("pomdp"))
-        .def("set_observation_memory_size", &synthesis::PomdpManager<double>::setObservationMemorySize, "Set memory size to a selected observation.", py::arg("observation"), py::arg("memory_size"))
-        .def("set_global_memory_size", &synthesis::PomdpManager<double>::setGlobalMemorySize, "Set memory size to all observations.", py::arg("memory_size"))
-        .def("construct_mdp", &synthesis::PomdpManager<double>::constructMdp, "Unfold memory model (a priori memory update) into the POMDP.")
-        .def_property_readonly("state_prototype", [](synthesis::PomdpManager<double>& manager) {return manager.state_prototype;})
-        .def_property_readonly("state_memory", [](synthesis::PomdpManager<double>& manager) {return manager.state_memory;})
-        .def_property_readonly("observation_memory_size", [](synthesis::PomdpManager<double>& manager) {return manager.observation_memory_size;})
-        .def_property_readonly("observation_actions", [](synthesis::PomdpManager<double>& manager) {return manager.observation_actions;})
-        .def_property_readonly("observation_successors", [](synthesis::PomdpManager<double>& manager) {return manager.observation_successors;})
-        .def_property_readonly("max_successor_memory_size", [](synthesis::PomdpManager<double>& manager) {return manager.max_successor_memory_size;})
-        .def_property_readonly("num_holes", [](synthesis::PomdpManager<double>& manager) {return manager.num_holes;})
-        .def_property_readonly("action_holes", [](synthesis::PomdpManager<double>& manager) {return manager.action_holes;})
-        .def_property_readonly("memory_holes", [](synthesis::PomdpManager<double>& manager) {return manager.memory_holes;})
-        .def_property_readonly("hole_options", [](synthesis::PomdpManager<double>& manager) {return manager.hole_options;})
-        .def_property_readonly("row_action_hole", [](synthesis::PomdpManager<double>& manager) {return manager.row_action_hole;})
-        .def_property_readonly("row_action_option", [](synthesis::PomdpManager<double>& manager) {return manager.row_action_option;})
-        .def_property_readonly("row_memory_hole", [](synthesis::PomdpManager<double>& manager) {return manager.row_memory_hole;})
-        .def_property_readonly("row_memory_option", [](synthesis::PomdpManager<double>& manager) {return manager.row_memory_option;})
+    py::class_<synthesis::PomdpManager<ValueType>>(m, (vtSuffix + "PomdpManager").c_str(), "POMDP manager")
+        .def(py::init<storm::models::sparse::Pomdp<ValueType> const&>(), "Constructor.", py::arg("pomdp"))
+        .def("set_observation_memory_size", &synthesis::PomdpManager<ValueType>::setObservationMemorySize, "Set memory size to a selected observation.", py::arg("observation"), py::arg("memory_size"))
+        .def("set_global_memory_size", &synthesis::PomdpManager<ValueType>::setGlobalMemorySize, "Set memory size to all observations.", py::arg("memory_size"))
+        .def("construct_mdp", &synthesis::PomdpManager<ValueType>::constructMdp, "Unfold memory model (a priori memory update) into the POMDP.")
+        .def_property_readonly("state_prototype", [](synthesis::PomdpManager<ValueType>& manager) {return manager.state_prototype;})
+        .def_property_readonly("state_memory", [](synthesis::PomdpManager<ValueType>& manager) {return manager.state_memory;})
+        .def_property_readonly("observation_memory_size", [](synthesis::PomdpManager<ValueType>& manager) {return manager.observation_memory_size;})
+        .def_property_readonly("observation_actions", [](synthesis::PomdpManager<ValueType>& manager) {return manager.observation_actions;})
+        .def_property_readonly("observation_successors", [](synthesis::PomdpManager<ValueType>& manager) {return manager.observation_successors;})
+        .def_property_readonly("max_successor_memory_size", [](synthesis::PomdpManager<ValueType>& manager) {return manager.max_successor_memory_size;})
+        .def_property_readonly("num_holes", [](synthesis::PomdpManager<ValueType>& manager) {return manager.num_holes;})
+        .def_property_readonly("action_holes", [](synthesis::PomdpManager<ValueType>& manager) {return manager.action_holes;})
+        .def_property_readonly("memory_holes", [](synthesis::PomdpManager<ValueType>& manager) {return manager.memory_holes;})
+        .def_property_readonly("hole_options", [](synthesis::PomdpManager<ValueType>& manager) {return manager.hole_options;})
+        .def_property_readonly("row_action_hole", [](synthesis::PomdpManager<ValueType>& manager) {return manager.row_action_hole;})
+        .def_property_readonly("row_action_option", [](synthesis::PomdpManager<ValueType>& manager) {return manager.row_action_option;})
+        .def_property_readonly("row_memory_hole", [](synthesis::PomdpManager<ValueType>& manager) {return manager.row_memory_hole;})
+        .def_property_readonly("row_memory_option", [](synthesis::PomdpManager<ValueType>& manager) {return manager.row_memory_option;})
         ;
 
-    py::class_<synthesis::PomdpManagerAposteriori<double>>(m, "PomdpManagerAposteriori", "POMDP manager (a posteriori)")
-        .def(py::init<storm::models::sparse::Pomdp<double> const&>(), "Constructor.")
-        .def("set_observation_memory_size", &synthesis::PomdpManagerAposteriori<double>::setObservationMemorySize)
-        .def("set_global_memory_size", &synthesis::PomdpManagerAposteriori<double>::setGlobalMemorySize)
-        .def("construct_mdp", &synthesis::PomdpManagerAposteriori<double>::constructMdp)
-        .def_property_readonly("state_prototype", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.state_prototype;})
-        .def_property_readonly("state_memory", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.state_memory;})
-        .def_property_readonly("coloring", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.coloring;})
-        .def_property_readonly("hole_num_options", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.hole_num_options;})
-        .def_property_readonly("action_holes", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.action_holes;})
-        .def_property_readonly("update_holes", [](synthesis::PomdpManagerAposteriori<double>& manager) {return manager.update_holes;})
+    py::class_<synthesis::PomdpManagerAposteriori<ValueType>>(m, (vtSuffix + "PomdpManagerAposteriori").c_str(), "POMDP manager (a posteriori)")
+        .def(py::init<storm::models::sparse::Pomdp<ValueType> const&>(), "Constructor.")
+        .def("set_observation_memory_size", &synthesis::PomdpManagerAposteriori<ValueType>::setObservationMemorySize)
+        .def("set_global_memory_size", &synthesis::PomdpManagerAposteriori<ValueType>::setGlobalMemorySize)
+        .def("construct_mdp", &synthesis::PomdpManagerAposteriori<ValueType>::constructMdp)
+        .def_property_readonly("state_prototype", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.state_prototype;})
+        .def_property_readonly("state_memory", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.state_memory;})
+        .def_property_readonly("coloring", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.coloring;})
+        .def_property_readonly("hole_num_options", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.hole_num_options;})
+        .def_property_readonly("action_holes", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.action_holes;})
+        .def_property_readonly("update_holes", [](synthesis::PomdpManagerAposteriori<ValueType>& manager) {return manager.update_holes;})
         ;
 
 }
 
+void bindings_pomdp(py::module& m) {
+    bindings_pomdp_vt<double>(m, "");
+    bindings_pomdp_vt<storm::RationalNumber>(m, "Exact");
+}

--- a/payntbind/src/synthesis/quotient/bindings.cpp
+++ b/payntbind/src/synthesis/quotient/bindings.cpp
@@ -19,6 +19,8 @@
 
 #include <storm/storage/Scheduler.h>
 
+#include <storm/adapters/RationalNumberAdapter.h>
+
 #include <z3++.h>
 
 namespace synthesis {
@@ -290,6 +292,8 @@ void bindings_coloring(py::module& m) {
     m.def("addChoiceLabelsFromJani", &synthesis::addChoiceLabelsFromJani<double>);
 
     m.def("schedulerToStateToGlobalChoice", &synthesis::schedulerToStateToGlobalChoice<double>);
+    m.def("schedulerToStateToGlobalChoiceExact", &synthesis::schedulerToStateToGlobalChoice<storm::RationalNumber>);
+
     m.def("computeInconsistentHoleVariance", &synthesis::computeInconsistentHoleVariance);
 
     m.def("policyToChoicesForFamily", &synthesis::policyToChoicesForFamily);

--- a/payntbind/src/synthesis/translation/SubPomdpBuilder.cpp
+++ b/payntbind/src/synthesis/translation/SubPomdpBuilder.cpp
@@ -1,6 +1,7 @@
 #include "SubPomdpBuilder.h"
 
 #include "src/synthesis/translation/componentTranslations.h"
+#include "storm/adapters/RationalNumberAdapter.h"
 
 #include <stack>
 
@@ -107,4 +108,5 @@ namespace synthesis {
     }
 
     template class SubPomdpBuilder<double>;
+    template class SubPomdpBuilder<storm::RationalNumber>;
 }

--- a/payntbind/src/synthesis/translation/bindings.cpp
+++ b/payntbind/src/synthesis/translation/bindings.cpp
@@ -3,26 +3,28 @@
 
 #include "src/synthesis/translation/componentTranslations.h"
 #include "src/synthesis/translation/choiceTransformation.h"
+#include <storm/adapters/RationalNumberAdapter.h>
 
-namespace synthesis {
+template <typename ValueType>
+void bindings_translation_vt(py::module& m, std::string const& vtSuffix) {
 
+    m.def(("computeChoiceDestinations" + vtSuffix).c_str(), &synthesis::computeChoiceDestinations<ValueType>);
+    m.def(("addMissingChoiceLabels" + vtSuffix).c_str(), &synthesis::addMissingChoiceLabelsModel<ValueType>);
+    m.def(("assertChoiceLabelingIsCanonic" + vtSuffix).c_str(), &synthesis::assertChoiceLabelingIsCanonic);
+    m.def(("extractActionLabels" + vtSuffix).c_str(), &synthesis::extractActionLabels<ValueType>);
+    m.def(("enableAllActions" + vtSuffix).c_str(), py::overload_cast<storm::models::sparse::Model<ValueType> const&>(&synthesis::enableAllActions<ValueType>));
+    m.def(("restoreActionsInAbsorbingStates" + vtSuffix).c_str(), &synthesis::restoreActionsInAbsorbingStates<ValueType>);
+    m.def(("addDontCareAction" + vtSuffix).c_str(), &synthesis::addDontCareAction<ValueType>);
+    m.def(("createModelUnion" + vtSuffix).c_str(), &synthesis::createModelUnion<ValueType>);
 
-}
-void bindings_translation(py::module& m) {
-
-    m.def("computeChoiceDestinations", &synthesis::computeChoiceDestinations<double>);
-    m.def("addMissingChoiceLabels", &synthesis::addMissingChoiceLabelsModel<double>);
-    m.def("assertChoiceLabelingIsCanonic", &synthesis::assertChoiceLabelingIsCanonic);
-    m.def("extractActionLabels", &synthesis::extractActionLabels<double>);
-    m.def("enableAllActions", py::overload_cast<storm::models::sparse::Model<double> const&>(&synthesis::enableAllActions<double>));
-    m.def("restoreActionsInAbsorbingStates", &synthesis::restoreActionsInAbsorbingStates<double>);
-    m.def("addDontCareAction", &synthesis::addDontCareAction<double>);
-    m.def("createModelUnion", &synthesis::createModelUnion<double>);
-
-    py::class_<synthesis::SubPomdpBuilder<double>, std::shared_ptr<synthesis::SubPomdpBuilder<double>>>(m, "SubPomdpBuilder")
-        .def(py::init<storm::models::sparse::Pomdp<double> const&>())
-        .def("start_from_belief", &synthesis::SubPomdpBuilder<double>::startFromBelief)
-        .def_property_readonly("state_sub_to_full", [](synthesis::SubPomdpBuilder<double>& b) {return b.state_sub_to_full;} )
+    py::class_<synthesis::SubPomdpBuilder<ValueType>, std::shared_ptr<synthesis::SubPomdpBuilder<ValueType>>>(m, ("SubPomdpBuilder" + vtSuffix).c_str())
+        .def(py::init<storm::models::sparse::Pomdp<ValueType> const&>())
+        .def("start_from_belief", &synthesis::SubPomdpBuilder<ValueType>::startFromBelief)
+        .def_property_readonly("state_sub_to_full", [](synthesis::SubPomdpBuilder<ValueType>& b) {return b.state_sub_to_full;} )
         ;
 }
 
+void bindings_translation(py::module& m) {
+    bindings_translation_vt<double>(m, "");
+    bindings_translation_vt<storm::RationalNumber>(m, "Exact");
+}

--- a/payntbind/src/synthesis/translation/choiceTransformation.cpp
+++ b/payntbind/src/synthesis/translation/choiceTransformation.cpp
@@ -2,6 +2,7 @@
 
 #include "src/synthesis/translation/componentTranslations.h"
 
+#include <storm/adapters/RationalNumberAdapter.h>
 #include <storm/exceptions/InvalidArgumentException.h>
 #include <storm/exceptions/InvalidModelException.h>
 #include <storm/exceptions/NotSupportedException.h>
@@ -590,6 +591,32 @@ template std::shared_ptr<storm::models::sparse::Model<double>> addDontCareAction
     storm::models::sparse::Model<double> const& model);
 template std::shared_ptr<storm::models::sparse::Model<double>> createModelUnion(
     std::vector<std::shared_ptr<storm::models::sparse::Model<double>>> const&
+);
+
+template std::vector<std::vector<uint64_t>> computeChoiceDestinations<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template std::pair<std::vector<std::string>,std::vector<uint64_t>> extractActionLabels<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template void addMissingChoiceLabelsLabeling<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    storm::models::sparse::ChoiceLabeling& choice_labeling);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> addMissingChoiceLabelsModel<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template std::pair<std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>>,std::vector<uint64_t>> enableAllActions(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template std::pair<std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>>,std::vector<uint64_t>> enableAllActions<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    storm::storage::BitVector const& state_mask);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> removeAction<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    std::string const& action_to_remove_label,
+    storm::storage::BitVector const& state_mask);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> restoreActionsInAbsorbingStates<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> addDontCareAction<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+template std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>> createModelUnion(
+    std::vector<std::shared_ptr<storm::models::sparse::Model<storm::RationalNumber>>> const&
 );
 
 }

--- a/payntbind/src/synthesis/translation/componentTranslations.cpp
+++ b/payntbind/src/synthesis/translation/componentTranslations.cpp
@@ -1,5 +1,6 @@
 #include "componentTranslations.h"
 
+#include <storm/adapters/RationalNumberAdapter.h>
 #include <storm/models/sparse/Pomdp.h>
 #include <storm/models/sparse/Smg.h>
 #include <storm/utility/builder.h>
@@ -206,4 +207,44 @@ template std::vector<uint32_t> translateObservabilityClasses<double>(
     storm::models::sparse::Model<double> const& model,
     std::vector<uint64_t> const& translated_to_original_state);
 
+
+
+
+template storm::storage::sparse::ModelComponents<storm::RationalNumber> componentsFromModel<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model);
+
+template storm::models::sparse::StateLabeling translateStateLabeling<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    std::vector<uint64_t> const& translated_to_original_state,
+    uint64_t translated_initial_state);
+
+template void translateTransitionMatrixRow<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    storm::storage::SparseMatrixBuilder<storm::RationalNumber> & builder,
+    std::vector<uint64_t> const& original_to_translated_state,
+    std::vector<uint64_t> const& original_to_translated_choice,
+    uint64_t choice);
+template void translateTransitionMatrixRowGroup<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    storm::storage::SparseMatrixBuilder<storm::RationalNumber> & builder,
+    std::vector<uint64_t> const& original_to_translated_state,
+    std::vector<uint64_t> const& original_to_translated_choice,
+    uint64_t state);
+
+template storm::models::sparse::ChoiceLabeling translateChoiceLabeling<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    std::vector<uint64_t> const& translated_to_original_choice,
+    storm::storage::BitVector const& translated_choice_mask);
+template storm::models::sparse::StandardRewardModel<storm::RationalNumber> translateRewardModel(
+    storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& reward_model,
+    std::vector<uint64_t> const& translated_to_original_choice,
+    storm::storage::BitVector const& translated_choice_mask);
+template std::unordered_map<std::string,storm::models::sparse::StandardRewardModel<storm::RationalNumber>> translateRewardModels(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    std::vector<uint64_t> const& translated_to_original_choice,
+    storm::storage::BitVector const& translated_choice_mask);
+
+template std::vector<uint32_t> translateObservabilityClasses<storm::RationalNumber>(
+    storm::models::sparse::Model<storm::RationalNumber> const& model,
+    std::vector<uint64_t> const& translated_to_original_state);
 }


### PR DESCRIPTION
This pull request contains a first implementation to get PAYNT to do exact calculations.
It only works for POMDPs (not sure if only memoryless). I tested it for several of the pomdp examples, and they all work. However, I thus only tested happy paths.

I also allowed the prism and drn parser to build models as exact. This can be used by calling `paynt.py` using the `--exact` flag.