### PR TITLE
Updated create wheels workflow

### DIFF
--- a/.github/workflows/before-all-linux.sh
+++ b/.github/workflows/before-all-linux.sh
@@ -6,32 +6,6 @@ set -e -u
 
 dnf install -y boost-devel cln-devel gmp-devel glpk-devel hwloc-devel z3-devel xerces-c-devel eigen3-devel python3-devel # missing ginac
 
-# Install stormpy from PyPI or from local wheel if NIGHTLY_BUILD is set
-if [[ "${NIGHTLY_BUILD:-false}" == "true" ]]; then
-	echo "Installing stormpy from local wheel (nightly build)"
-	PYTAG=$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
-	SOABI=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
-	WHEEL_DIR="${STORMPY_WHEEL_DIR:-$(pwd)/stormpy_wheels}"
-	echo "Looking for stormpy wheels in: $WHEEL_DIR"
-	ls -la "$WHEEL_DIR" || true
-	if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
-		WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
-	else
-		WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
-	fi
-	if [[ -z "${WHEEL:-}" ]]; then
-		echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
-		echo "Available wheels:" >&2
-		ls -la "$WHEEL_DIR" >&2 || true
-		exit 1
-	fi
-	echo "Installing stormpy wheel: $WHEEL"
-	python3 -m pip install --force-reinstall "$WHEEL"
-else
-	echo "Installing stormpy from PyPI"
-	python3 -m pip install stormpy
-fi
-
 cd /tmp
 
 # Install ginac
@@ -56,15 +30,11 @@ tar -xzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 mkdir -p "${BOOST_PREFIX}/include"
 cp -a "boost_${BOOST_VERSION_UNDERSCORE}/boost" "${BOOST_PREFIX}/include/"
 
-# Query stormpy.info.storm_origin_info() and store into variables
-read -r storm_repository storm_tag storm_commit_hash < <(
-	python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())"
-)
 
 # Install Storm
-git clone "${storm_repository}"
+git clone "${STORM_REPOSITORY}"
 cd storm
-git checkout "${storm_commit_hash}"
+git checkout "${STORM_COMMIT_HASH}"
 mkdir build
 cd build
 cmake .. -DSTORM_BUILD_TESTS=OFF -DSTORM_BUILD_EXECUTABLES=OFF -DSTORM_PORTABLE=ON

--- a/.github/workflows/before-all-linux.sh
+++ b/.github/workflows/before-all-linux.sh
@@ -6,6 +6,32 @@ set -e -u
 
 dnf install -y boost-devel cln-devel gmp-devel glpk-devel hwloc-devel z3-devel xerces-c-devel eigen3-devel python3-devel # missing ginac
 
+# Install stormpy from PyPI or from local wheel if NIGHTLY_BUILD is set
+if [[ "${NIGHTLY_BUILD:-false}" == "true" ]]; then
+	echo "Installing stormpy from local wheel (nightly build)"
+	PYTAG=$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+	SOABI=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
+	WHEEL_DIR="${STORMPY_WHEEL_DIR:-$(pwd)/stormpy_wheels}"
+	echo "Looking for stormpy wheels in: $WHEEL_DIR"
+	ls -la "$WHEEL_DIR" || true
+	if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
+		WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
+	else
+		WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
+	fi
+	if [[ -z "${WHEEL:-}" ]]; then
+		echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
+		echo "Available wheels:" >&2
+		ls -la "$WHEEL_DIR" >&2 || true
+		exit 1
+	fi
+	echo "Installing stormpy wheel: $WHEEL"
+	python3 -m pip install --force-reinstall "$WHEEL"
+else
+	echo "Installing stormpy from PyPI"
+	python3 -m pip install stormpy
+fi
+
 cd /tmp
 
 # Install ginac
@@ -30,10 +56,15 @@ tar -xzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 mkdir -p "${BOOST_PREFIX}/include"
 cp -a "boost_${BOOST_VERSION_UNDERSCORE}/boost" "${BOOST_PREFIX}/include/"
 
+# Query stormpy.info.storm_origin_info() and store into variables
+read -r storm_repository storm_tag storm_commit_hash < <(
+	python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())"
+)
+
 # Install Storm
-: "${STORM_VERSION:=master}"
-git clone --depth 1 https://github.com/moves-rwth/storm.git -b "${STORM_VERSION}"
+git clone "${storm_repository}"
 cd storm
+git checkout "${storm_commit_hash}"
 mkdir build
 cd build
 cmake .. -DSTORM_BUILD_TESTS=OFF -DSTORM_BUILD_EXECUTABLES=OFF -DSTORM_PORTABLE=ON

--- a/.github/workflows/before-all-linux.sh
+++ b/.github/workflows/before-all-linux.sh
@@ -18,19 +18,15 @@ make -j ${NR_JOBS}
 make install
 cd ..
 
-# Install Boost 1.83 headers (no full build)
-#
-# Building all Boost libraries from source is extremely slow on GitHub-hosted Linux runners
-# and is unnecessary for our use (we only need Boost headers at >= 1.83 for compilation).
+# Install Boost 1.83 from source
 BOOST_VERSION=1.83.0
 BOOST_VERSION_UNDERSCORE=${BOOST_VERSION//./_}
-BOOST_PREFIX=/opt/boost_${BOOST_VERSION_UNDERSCORE}
 curl -fsSLO https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 tar -xzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
-mkdir -p "${BOOST_PREFIX}/include"
-cp -a "boost_${BOOST_VERSION_UNDERSCORE}/boost" "${BOOST_PREFIX}/include/"
-# Set BOOST_ROOT environment variable for CMake
-export BOOST_ROOT="${BOOST_PREFIX}"
+cd boost_${BOOST_VERSION_UNDERSCORE}
+./bootstrap.sh --prefix=/usr/local
+./b2 install -j ${NR_JOBS}
+cd ..
 
 
 # Install Storm

--- a/.github/workflows/before-all-linux.sh
+++ b/.github/workflows/before-all-linux.sh
@@ -29,6 +29,8 @@ curl -fsSLO https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BO
 tar -xzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 mkdir -p "${BOOST_PREFIX}/include"
 cp -a "boost_${BOOST_VERSION_UNDERSCORE}/boost" "${BOOST_PREFIX}/include/"
+# Set BOOST_ROOT environment variable for CMake
+export BOOST_ROOT="${BOOST_PREFIX}"
 
 
 # Install Storm

--- a/.github/workflows/before-all-macos.sh
+++ b/.github/workflows/before-all-macos.sh
@@ -6,10 +6,41 @@ set -e -u
 
 brew install ccache automake boost cln ginac glpk hwloc z3 xerces-c
 
+# Install stormpy from PyPI or from local wheel if NIGHTLY_BUILD is set
+if [[ "${NIGHTLY_BUILD:-false}" == "true" ]]; then
+	echo "Installing stormpy from local wheel (nightly build)"
+	PYTAG=$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+	SOABI=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
+	WHEEL_DIR="${STORMPY_WHEEL_DIR:-$(pwd)/stormpy_wheels}"
+	echo "Looking for stormpy wheels in: $WHEEL_DIR"
+	ls -la "$WHEEL_DIR" || true
+	if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
+		WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
+	else
+		WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
+	fi
+	if [[ -z "${WHEEL:-}" ]]; then
+		echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
+		echo "Available wheels:" >&2
+		ls -la "$WHEEL_DIR" >&2 || true
+		exit 1
+	fi
+	echo "Installing stormpy wheel: $WHEEL"
+	python3 -m pip install --force-reinstall "$WHEEL"
+else
+	echo "Installing stormpy from PyPI"
+	python3 -m pip install stormpy
+fi
+
+# Query stormpy.info.storm_origin_info() and store into variables
+read -r storm_repository storm_tag storm_commit_hash < <(
+	python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())"
+)
+
 # Install Storm
-: "${STORM_VERSION:=master}"
-git clone --depth 1 https://github.com/moves-rwth/storm.git -b "${STORM_VERSION}"
+git clone "${storm_repository}"
 cd storm
+git checkout "${storm_commit_hash}"
 mkdir build
 cd build
 cmake .. -DSTORM_BUILD_TESTS=OFF -DSTORM_BUILD_EXECUTABLES=OFF -DSTORM_PORTABLE=ON

--- a/.github/workflows/before-all-macos.sh
+++ b/.github/workflows/before-all-macos.sh
@@ -6,41 +6,10 @@ set -e -u
 
 brew install ccache automake boost cln ginac glpk hwloc z3 xerces-c
 
-# Install stormpy from PyPI or from local wheel if NIGHTLY_BUILD is set
-if [[ "${NIGHTLY_BUILD:-false}" == "true" ]]; then
-	echo "Installing stormpy from local wheel (nightly build)"
-	PYTAG=$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
-	SOABI=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
-	WHEEL_DIR="${STORMPY_WHEEL_DIR:-$(pwd)/stormpy_wheels}"
-	echo "Looking for stormpy wheels in: $WHEEL_DIR"
-	ls -la "$WHEEL_DIR" || true
-	if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
-		WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
-	else
-		WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
-	fi
-	if [[ -z "${WHEEL:-}" ]]; then
-		echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
-		echo "Available wheels:" >&2
-		ls -la "$WHEEL_DIR" >&2 || true
-		exit 1
-	fi
-	echo "Installing stormpy wheel: $WHEEL"
-	python3 -m pip install --force-reinstall "$WHEEL"
-else
-	echo "Installing stormpy from PyPI"
-	python3 -m pip install stormpy
-fi
-
-# Query stormpy.info.storm_origin_info() and store into variables
-read -r storm_repository storm_tag storm_commit_hash < <(
-	python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())"
-)
-
 # Install Storm
-git clone "${storm_repository}"
+git clone "${STORM_REPOSITORY}"
 cd storm
-git checkout "${storm_commit_hash}"
+git checkout "${STORM_COMMIT_HASH}"
 mkdir build
 cd build
 cmake .. -DSTORM_BUILD_TESTS=OFF -DSTORM_BUILD_EXECUTABLES=OFF -DSTORM_PORTABLE=ON

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -71,13 +71,13 @@ jobs:
               ls -la stormpy_wheels/ >&2 || true
               exit 1
             fi
-            python -m venv venv
+            python3 -m venv venv
             source venv/bin/activate
-            python -m pip install --force-reinstall "$WHEEL"
+            python3 -m pip install --force-reinstall "$WHEEL"
           else
-            python -m venv venv
+            python3 -m venv venv
             source venv/bin/activate
-            python -m pip install stormpy
+            python3 -m pip install stormpy
           fi
 
           read -r storm_repository storm_tag storm_commit_hash < <( \

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -148,8 +148,18 @@ jobs:
           perl -i -pe 's/__version__ = "(\d+)\.(\d+)\.(\d+)"/"__version__ = \"$1.$2.".($3+1).".dev1\""/e' payntbind/lib/payntbind/_version.py
       - name: Prepare storm version
         run: |
-          sed -i -E 's/STORM_GIT_REPO="(.+)"/STORM_GIT_REPO="${{ needs.get_storm_version.outputs.storm_repository }}"/' pyproject.toml
-          sed -i -E 's/STORM_GIT_TAG="(.+)"/STORM_GIT_TAG="${{ needs.get_storm_version.outputs.storm_tag }}"/' pyproject.toml
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          p = Path("pyproject.toml")
+          s = p.read_text()
+
+          s = re.sub(r'STORM_GIT_REPO="[^"]*"', 'STORM_GIT_REPO="${{ needs.get_storm_version.outputs.storm_repository }}"', s)
+          s = re.sub(r'STORM_GIT_TAG="[^"]*"',  'STORM_GIT_TAG="${{ needs.get_storm_version.outputs.storm_commit_hash }}"', s)
+
+          p.write_text(s)
+          PY
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install stormpy nightly
         id: get_versions
         run: |
-          docker run -i --rm -v ./dist:/wheel ubuntu:latest /bin/bash << 'EOF'
+          docker run -i --rm -v ./stormpy_wheels:/stormpy_wheels ubuntu:latest /bin/bash << 'EOF'
           set -euo pipefail
           set -x
 
@@ -64,7 +64,7 @@ jobs:
           echo "Python version: $PY_VER"
 
           if ${{ env.NIGHTLY_BUILD }}; then
-            WHEEL_DIR="$(pwd)/stormpy_wheels"
+            WHEEL_DIR="stormpy_wheels"
             WHEEL=$(ls "$WHEEL_DIR"/*-cp${PY_VER}-cp${PY_VER}-*.whl 2>/dev/null | head -n 1 || true)
             if [[ -z "${WHEEL:-}" ]]; then
               echo "No stormpy wheel found in stormpy_wheels/" >&2

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -50,7 +50,7 @@ jobs:
           repo: stormchecker/stormpy
           name: ${{ env.STORMPY_ARTIFACT_NAME }}
           path: stormpy_wheels/
-      - name: Install stormpy nightly
+      - name: Install stormpy
         id: get_versions
         run: |
           docker run -i --rm -v ./stormpy_wheels:/stormpy_wheels ubuntu:latest /bin/bash << 'EOF'
@@ -83,14 +83,22 @@ jobs:
           read -r storm_repository storm_tag storm_commit_hash < <( \
             python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())" \
           )
-          echo "STORM_REPOSITORY=$storm_repository" >> $GITHUB_OUTPUT
-          echo "STORM_TAG=$storm_tag" >> $GITHUB_OUTPUT
-          echo "STORM_COMMIT_HASH=$storm_commit_hash" >> $GITHUB_OUTPUT
+          stormpy_version=$(python3 -c "import stormpy; print(stormpy.__version__)")
 
-          read -r stormpy_version < <( \
-            python3 -c "import stormpy; print(stormpy.__version__)" \
-          )
-          echo "STORMPY_VERSION=$stormpy_version" >> $GITHUB_OUTPUT
+          # Write results to a file in the mounted directory
+          {
+            echo "storm_repository=$storm_repository"
+            echo "storm_tag=$storm_tag"
+            echo "storm_commit_hash=$storm_commit_hash"
+            echo "stormpy_version=$stormpy_version"
+          } > /stormpy_wheels/versions.env
+          EOF
+
+          # Export container results as step outputs (host environment)
+          cat stormpy_wheels/versions.env
+          while IFS='=' read -r k v; do
+            echo "$k=$v" >> "$GITHUB_OUTPUT"
+          done < stormpy_wheels/versions.env
 
   build_wheels:
     name: Build wheels for ${{ matrix.os }}

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set STORMPY_ARTIFACT_NAME
         if: env.NIGHTLY_BUILD == 'true'
         run: |
-          echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-linux-intel" >> $GITHUB_ENV ;;
+          echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-linux-intel" >> $GITHUB_ENV
       - name: Download stormpy nightly wheel if NIGHTLY_BUILD
         if: env.NIGHTLY_BUILD == 'true'
         uses: dawidd6/action-download-artifact@v20

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Set NIGHTLY_BUILD flag
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.event.inputs.nightly }}" == true ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.nightly }}" == true ]]; then
             echo "NIGHTLY_BUILD=true" >> $GITHUB_ENV
           else
             echo "NIGHTLY_BUILD=false" >> $GITHUB_ENV
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Set NIGHTLY_BUILD flag
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.event.inputs.nightly }}" == true ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.nightly }}" == true ]]; then
             echo "NIGHTLY_BUILD=true" >> $GITHUB_ENV
           else
             echo "NIGHTLY_BUILD=false" >> $GITHUB_ENV
@@ -179,7 +179,7 @@ jobs:
     steps:
       - name: Set NIGHTLY_BUILD flag
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.event.inputs.nightly }}" == true ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.nightly }}" == true ]]; then
             echo "NIGHTLY_BUILD=true" >> $GITHUB_ENV
           else
             echo "NIGHTLY_BUILD=false" >> $GITHUB_ENV

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -5,13 +5,19 @@ on:
     # run weekly
     - cron: '0 10 * * 3'
   workflow_call:
+    inputs:
+      nightly:
+        description: 'Build nightly/dev wheels (use stormpy nightly)'
+        required: true
+        default: false
+        type: boolean
   # needed to trigger the workflow manually
   workflow_dispatch:
     inputs:
       nightly:
         description: 'Build nightly/dev wheels (use stormpy nightly)'
-        required: false
-        default: true
+        required: true
+        default: false
         type: boolean
 
 jobs:
@@ -84,52 +90,51 @@ jobs:
         run: | 
           perl -i -pe 's/__version__ = "(\d+)\.(\d+)\.(\d+)"/"__version__ = \"$1.$2.".($3+1).".dev1\""/e' paynt/_version.py
           perl -i -pe 's/__version__ = "(\d+)\.(\d+)\.(\d+)"/"__version__ = \"$1.$2.".($3+1).".dev1\""/e' payntbind/lib/payntbind/_version.py
-      - name: Build wheels
+      - name: Build wheels (nightly)
         uses: pypa/cibuildwheel@v3.4.1
         if: env.NIGHTLY_BUILD == 'true'
         env:
           CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
-          CIBW_ENVIRONMENT: NR_JOBS=4
-          CIBW_ENVIRONMENT_LINUX: NR_JOBS=4 BOOST_ROOT=/opt/boost_1_83_0 BOOST_INCLUDEDIR=/opt/boost_1_83_0/include STORM_VERSION=master
+          CIBW_ENVIRONMENT: NR_JOBS=4 NIGHTLY_BUILD=true
 
           # Key: use pip as the build frontend, and pass --no-build-isolation
-          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          # CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
 
-          CIBW_BEFORE_BUILD: |
-            python -m pip install -U pip
+          # CIBW_BEFORE_BUILD: |
+          #   python -m pip install -U pip
 
-            PYTAG=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
-            SOABI=$(python -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
+          #   PYTAG=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+          #   SOABI=$(python -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
 
-            WHEEL_DIR="$(pwd)/stormpy_wheels"
-            echo "Looking for stormpy wheels in: $WHEEL_DIR"
-            ls -la "$WHEEL_DIR" || true
+          #   WHEEL_DIR="$(pwd)/stormpy_wheels"
+          #   echo "Looking for stormpy wheels in: $WHEEL_DIR"
+          #   ls -la "$WHEEL_DIR" || true
 
-            echo "PYTAG=$PYTAG"
-            echo "SOABI=$SOABI"
+          #   echo "PYTAG=$PYTAG"
+          #   echo "SOABI=$SOABI"
 
-            # Free-threaded builds have "t" in SOABI (e.g. cpython-314t-darwin)
-            if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
-              echo "Detected Python 3.14 free-threaded ($SOABI) -> installing cp314t stormpy"
-              WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
-            else
-              echo "Detected non-free-threaded Python ($SOABI) -> installing cp${PYTAG} stormpy"
-              WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
-            fi
+          #   # Free-threaded builds have "t" in SOABI (e.g. cpython-314t-darwin)
+          #   if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
+          #     echo "Detected Python 3.14 free-threaded ($SOABI) -> installing cp314t stormpy"
+          #     WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
+          #   else
+          #     echo "Detected non-free-threaded Python ($SOABI) -> installing cp${PYTAG} stormpy"
+          #     WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
+          #   fi
 
-            if [[ -z "${WHEEL:-}" ]]; then
-              echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
-              echo "Available wheels:" >&2
-              ls -la "$WHEEL_DIR" >&2 || true
-              exit 1
-            fi
+          #   if [[ -z "${WHEEL:-}" ]]; then
+          #     echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
+          #     echo "Available wheels:" >&2
+          #     ls -la "$WHEEL_DIR" >&2 || true
+          #     exit 1
+          #   fi
 
-            echo "Installing stormpy wheel: $WHEEL"
-            python -m pip install --force-reinstall "$WHEEL"
-            python -c "import stormpy; print('stormpy from:', stormpy.__file__)"
-            python -m pip install scikit-build-core pybind11
+          #   echo "Installing stormpy wheel: $WHEEL"
+          #   python -m pip install --force-reinstall "$WHEEL"
+          #   python -c "import stormpy; print('stormpy from:', stormpy.__file__)"
+          #   python -m pip install scikit-build-core pybind11
       - name: Build wheels (non-nightly)
         uses: pypa/cibuildwheel@v3.4.1
         if: env.NIGHTLY_BUILD != 'true'
@@ -137,8 +142,7 @@ jobs:
           CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
-          CIBW_ENVIRONMENT: NR_JOBS=4
-          CIBW_ENVIRONMENT_LINUX: NR_JOBS=4 BOOST_ROOT=/opt/boost_1_83_0 BOOST_INCLUDEDIR=/opt/boost_1_83_0/include STORM_VERSION=master
+          CIBW_ENVIRONMENT: NR_JOBS=4 NIGHTLY_BUILD=false
       - uses: actions/upload-artifact@v7
         with:
           name: paynt-wheels-${{ matrix.os }}

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -46,7 +46,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: create_wheel.yml
+          workflow: create_wheel_scheduled.yml
           repo: stormchecker/stormpy
           name: ${{ env.STORMPY_ARTIFACT_NAME }}
           path: stormpy_wheels/

--- a/.github/workflows/create_wheel.yml
+++ b/.github/workflows/create_wheel.yml
@@ -21,8 +21,80 @@ on:
         type: boolean
 
 jobs:
+  get_storm_version:
+    name: Install stormpy and get storm version
+    runs-on: ubuntu-latest
+    outputs:
+      storm_repository: ${{ steps.get_versions.outputs.storm_repository }}
+      storm_tag: ${{ steps.get_versions.outputs.storm_tag }}
+      storm_commit_hash: ${{ steps.get_versions.outputs.storm_commit_hash }}
+      stormpy_version: ${{ steps.get_versions.outputs.stormpy_version }}
+    steps:
+      - name: Set NIGHTLY_BUILD flag
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.event.inputs.nightly }}" == true ]]; then
+            echo "NIGHTLY_BUILD=true" >> $GITHUB_ENV
+          else
+            echo "NIGHTLY_BUILD=false" >> $GITHUB_ENV
+          fi
+      - name: Set STORMPY_ARTIFACT_NAME
+        if: env.NIGHTLY_BUILD == 'true'
+        run: |
+          echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-linux-intel" >> $GITHUB_ENV ;;
+      - name: Download stormpy nightly wheel if NIGHTLY_BUILD
+        if: env.NIGHTLY_BUILD == 'true'
+        uses: dawidd6/action-download-artifact@v20
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: create_wheel.yml
+          repo: stormchecker/stormpy
+          name: ${{ env.STORMPY_ARTIFACT_NAME }}
+          path: stormpy_wheels/
+      - name: Install stormpy nightly
+        id: get_versions
+        run: |
+          docker run -i --rm -v ./dist:/wheel ubuntu:latest /bin/bash << 'EOF'
+          set -euo pipefail
+          set -x
+
+          apt update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y python3 python3-pip python3-venv python3-dev
+
+          # Get major+minor version (e.g. "311" for Python 3.11)
+          PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+          echo "Python version: $PY_VER"
+
+          if ${{ env.NIGHTLY_BUILD }}; then
+            WHEEL_DIR="$(pwd)/stormpy_wheels"
+            WHEEL=$(ls "$WHEEL_DIR"/*-cp${PY_VER}-cp${PY_VER}-*.whl 2>/dev/null | head -n 1 || true)
+            if [[ -z "${WHEEL:-}" ]]; then
+              echo "No stormpy wheel found in stormpy_wheels/" >&2
+              ls -la stormpy_wheels/ >&2 || true
+              exit 1
+            fi
+            python -m venv venv
+            source venv/bin/activate
+            python -m pip install --force-reinstall "$WHEEL"
+          else
+            python -m venv venv
+            source venv/bin/activate
+            python -m pip install stormpy
+          fi
+
+          read -r storm_repository storm_tag storm_commit_hash < <( \
+            python3 -c "import stormpy.info; print(*stormpy.info.storm_origin_info())" \
+          )
+          echo "STORM_REPOSITORY=$storm_repository" >> $GITHUB_OUTPUT
+          echo "STORM_TAG=$storm_tag" >> $GITHUB_OUTPUT
+          echo "STORM_COMMIT_HASH=$storm_commit_hash" >> $GITHUB_OUTPUT
+
+          read -r stormpy_version < <( \
+            python3 -c "import stormpy; print(stormpy.__version__)" \
+          )
+          echo "STORMPY_VERSION=$stormpy_version" >> $GITHUB_OUTPUT
+
   build_wheels:
     name: Build wheels for ${{ matrix.os }}
+    needs: get_storm_version
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
@@ -61,88 +133,22 @@ jobs:
         if: ${{ matrix.xcode != '' }}
         with:
           xcode-version: ${{ matrix.xcode }}
-      - name: Set STORMPY_ARTIFACT_NAME
-        if: env.NIGHTLY_BUILD == 'true'
-        run: |
-          case "${{ matrix.os }}" in
-            linux-intel)
-              echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-linux-intel" >> $GITHUB_ENV ;;
-            linux-arm)
-              echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-linux-arm" >> $GITHUB_ENV ;;
-            macos-intel)
-              echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-macos-intel" >> $GITHUB_ENV ;;
-            macos-arm)
-              echo "STORMPY_ARTIFACT_NAME=stormpy-wheels-macos-arm" >> $GITHUB_ENV ;;
-            *)
-              echo "Unknown matrix.os: ${{ matrix.os }}" >&2; exit 1 ;;
-          esac
-      - name: Download stormpy nightly wheel if NIGHTLY_BUILD
-        if: env.NIGHTLY_BUILD == 'true'
-        uses: dawidd6/action-download-artifact@v20
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: create_wheel.yml
-          repo: stormchecker/stormpy
-          name: ${{ env.STORMPY_ARTIFACT_NAME }}
-          path: stormpy_wheels/
       - name: Prepare nightly version
         if: env.NIGHTLY_BUILD == 'true'
         run: | 
           perl -i -pe 's/__version__ = "(\d+)\.(\d+)\.(\d+)"/"__version__ = \"$1.$2.".($3+1).".dev1\""/e' paynt/_version.py
           perl -i -pe 's/__version__ = "(\d+)\.(\d+)\.(\d+)"/"__version__ = \"$1.$2.".($3+1).".dev1\""/e' payntbind/lib/payntbind/_version.py
-      - name: Build wheels (nightly)
+      - name: Prepare storm version
+        run: |
+          sed -i -E 's/STORM_GIT_REPO="(.+)"/STORM_GIT_REPO="${{ needs.get_storm_version.outputs.storm_repository }}"/' pyproject.toml
+          sed -i -E 's/STORM_GIT_TAG="(.+)"/STORM_GIT_TAG="${{ needs.get_storm_version.outputs.storm_tag }}"/' pyproject.toml
+      - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
-        if: env.NIGHTLY_BUILD == 'true'
         env:
           CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
-          CIBW_ENVIRONMENT: NR_JOBS=4 NIGHTLY_BUILD=true
-
-          # Key: use pip as the build frontend, and pass --no-build-isolation
-          # CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-
-          # CIBW_BEFORE_BUILD: |
-          #   python -m pip install -U pip
-
-          #   PYTAG=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
-          #   SOABI=$(python -c "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')")
-
-          #   WHEEL_DIR="$(pwd)/stormpy_wheels"
-          #   echo "Looking for stormpy wheels in: $WHEEL_DIR"
-          #   ls -la "$WHEEL_DIR" || true
-
-          #   echo "PYTAG=$PYTAG"
-          #   echo "SOABI=$SOABI"
-
-          #   # Free-threaded builds have "t" in SOABI (e.g. cpython-314t-darwin)
-          #   if [[ "$PYTAG" == "314" && "$SOABI" == *"314t"* ]]; then
-          #     echo "Detected Python 3.14 free-threaded ($SOABI) -> installing cp314t stormpy"
-          #     WHEEL=$(ls "$WHEEL_DIR"/*-cp314-cp314t-*.whl 2>/dev/null | head -n 1 || true)
-          #   else
-          #     echo "Detected non-free-threaded Python ($SOABI) -> installing cp${PYTAG} stormpy"
-          #     WHEEL=$(ls "$WHEEL_DIR"/*-cp${PYTAG}-cp${PYTAG}-*.whl 2>/dev/null | head -n 1 || true)
-          #   fi
-
-          #   if [[ -z "${WHEEL:-}" ]]; then
-          #     echo "No matching stormpy wheel found for PYTAG=$PYTAG SOABI=$SOABI" >&2
-          #     echo "Available wheels:" >&2
-          #     ls -la "$WHEEL_DIR" >&2 || true
-          #     exit 1
-          #   fi
-
-          #   echo "Installing stormpy wheel: $WHEEL"
-          #   python -m pip install --force-reinstall "$WHEEL"
-          #   python -c "import stormpy; print('stormpy from:', stormpy.__file__)"
-          #   python -m pip install scikit-build-core pybind11
-      - name: Build wheels (non-nightly)
-        uses: pypa/cibuildwheel@v3.4.1
-        if: env.NIGHTLY_BUILD != 'true'
-        env:
-          CIBW_PLATFORM: ${{ matrix.platform }}
-          CIBW_ARCHS: ${{ matrix.archs }}
-          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deploy_target }}
-          CIBW_ENVIRONMENT: NR_JOBS=4 NIGHTLY_BUILD=false
+          CIBW_ENVIRONMENT: NR_JOBS=4 STORM_REPOSITORY=${{ needs.get_storm_version.outputs.storm_repository }} STORM_TAG=${{ needs.get_storm_version.outputs.storm_tag }} STORM_COMMIT_HASH=${{ needs.get_storm_version.outputs.storm_commit_hash }} STORMPY_VERSION=${{ needs.get_storm_version.outputs.stormpy_version }}
       - uses: actions/upload-artifact@v7
         with:
           name: paynt-wheels-${{ matrix.os }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -111,6 +111,8 @@ jobs:
     # Create wheels and sdist
     needs: [env_storm_versions, deploy_docker, deploy_docker_stable]
     uses: ./.github/workflows/create_wheel.yml
+    with:
+      nightly: false
     secrets: inherit
 
   deploy_pypi:

--- a/.github/workflows/test_wheelpypi.yml
+++ b/.github/workflows/test_wheelpypi.yml
@@ -9,6 +9,8 @@ jobs:
   create_wheels:
     # Create wheels and sdist
     uses: ./.github/workflows/create_wheel.yml
+    with:
+      nightly: false
     secrets: inherit
 
   upload_testpypi:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,79 +10,83 @@ option(ALLOW_STORM_SYSTEM "Allow finding a storm version on the system" ON)
 option(ALLOW_STORM_FETCH "Allow fetching storm" ON)
 set(STORM_GIT_REPO "" CACHE STRING  "Git repo used for fetching storm")
 set(STORM_GIT_TAG "" CACHE STRING "Git repo tag used for fetching storm")
+option(PAYNT_INFO_PRETEND_FETCH "[INTERNAL] Use for overriding some flags in the info by cibuildwheel." OFF)
+mark_as_advanced(PAYNT_INFO_PRETEND_FETCH)
 
-# Query stormpy.info to determine Storm configuration
-execute_process(
-    COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; print(stormpy.info.storm_from_system())"
-    RESULT_VARIABLE _stormpy_result
-    OUTPUT_VARIABLE STORMPY_FROM_SYSTEM
-    ERROR_VARIABLE _stormpy_error
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(NOT _stormpy_result EQUAL 0)
-    message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_from_system(): ${_stormpy_error}")
-endif()
-
-# Configure Storm settings based on stormpy configuration
-if(STORMPY_FROM_SYSTEM STREQUAL "True")
+if (NOT PAYNT_INFO_PRETEND_FETCH)
+    # Query stormpy.info to determine Storm configuration
     execute_process(
-        COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; print(stormpy.info.storm_directory())"
-        RESULT_VARIABLE _directory_result
-        OUTPUT_VARIABLE STORM_DIRECTORY_INFO
-        ERROR_VARIABLE _origin_error
+        COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; print(stormpy.info.storm_from_system())"
+        RESULT_VARIABLE _stormpy_result
+        OUTPUT_VARIABLE STORMPY_FROM_SYSTEM
+        ERROR_VARIABLE _stormpy_error
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    if(NOT _directory_result EQUAL 0)
-        message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_directory(): ${_origin_error}")
+    if(NOT _stormpy_result EQUAL 0)
+        message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_from_system(): ${_stormpy_error}")
     endif()
 
-    message(STATUS "PAYNT - StormPy uses system Storm from: ${STORM_DIRECTORY_INFO} - configuring PAYNT to use the same system Storm")
+    # Configure Storm settings based on stormpy configuration
+    if(STORMPY_FROM_SYSTEM STREQUAL "True")
+        execute_process(
+            COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; print(stormpy.info.storm_directory())"
+            RESULT_VARIABLE _directory_result
+            OUTPUT_VARIABLE STORM_DIRECTORY_INFO
+            ERROR_VARIABLE _origin_error
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
 
-    set(STORM_DIR_HINT "${STORM_DIRECTORY_INFO}")
-    set(ALLOW_STORM_SYSTEM ON)
-    set(ALLOW_STORM_FETCH OFF)
-else()
-    message(STATUS "PAYNT - StormPy uses fetched Storm - querying Storm origin information")
+        if(NOT _directory_result EQUAL 0)
+            message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_directory(): ${_origin_error}")
+        endif()
 
-    # Get Storm origin information
-    execute_process(
-        COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; repo, tag, hash = stormpy.info.storm_origin_info(); print(f'{repo or \"\"};{tag or \"\"};{hash or \"\"}')"
-        RESULT_VARIABLE _origin_result
-        OUTPUT_VARIABLE STORM_ORIGIN_INFO
-        ERROR_VARIABLE _origin_error
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    
-    if(NOT _origin_result EQUAL 0)
-        message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_origin_info(): ${_origin_error}")
-    endif()
-    
-    # Parse repo and tag
-    list(GET STORM_ORIGIN_INFO 0 STORM_ORIGIN_REPO)
-    list(GET STORM_ORIGIN_INFO 2 STORM_ORIGIN_TAG)
-    
-    message(STATUS "PAYNT - Storm origin repo: ${STORM_ORIGIN_REPO}")
-    message(STATUS "PAYNT - Storm origin tag: ${STORM_ORIGIN_TAG}")
-    
-    # Configure to fetch the same Storm version as stormpy
-    set(ALLOW_STORM_SYSTEM OFF)
-    set(ALLOW_STORM_FETCH ON)
-    
-    if(NOT STORM_ORIGIN_REPO STREQUAL "")
-        set(STORM_GIT_REPO "${STORM_ORIGIN_REPO}")
+        message(STATUS "PAYNT - StormPy uses system Storm from: ${STORM_DIRECTORY_INFO} - configuring PAYNT to use the same system Storm")
+
+        set(STORM_DIR_HINT "${STORM_DIRECTORY_INFO}")
+        set(ALLOW_STORM_SYSTEM ON)
+        set(ALLOW_STORM_FETCH OFF)
     else()
-        message(FATAL_ERROR "PAYNT - Failed to determine Storm origin repository")
+        message(STATUS "PAYNT - StormPy uses fetched Storm - querying Storm origin information")
+
+        # Get Storm origin information
+        execute_process(
+            COMMAND "${Python_EXECUTABLE}" -c "import stormpy.info; repo, tag, hash = stormpy.info.storm_origin_info(); print(f'{repo or \"\"};{tag or \"\"};{hash or \"\"}')"
+            RESULT_VARIABLE _origin_result
+            OUTPUT_VARIABLE STORM_ORIGIN_INFO
+            ERROR_VARIABLE _origin_error
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        
+        if(NOT _origin_result EQUAL 0)
+            message(FATAL_ERROR "PAYNT - Failed to query stormpy.info.storm_origin_info(): ${_origin_error}")
+        endif()
+        
+        # Parse repo and tag
+        list(GET STORM_ORIGIN_INFO 0 STORM_ORIGIN_REPO)
+        list(GET STORM_ORIGIN_INFO 2 STORM_ORIGIN_TAG)
+        
+        message(STATUS "PAYNT - Storm origin repo: ${STORM_ORIGIN_REPO}")
+        message(STATUS "PAYNT - Storm origin tag: ${STORM_ORIGIN_TAG}")
+        
+        # Configure to fetch the same Storm version as stormpy
+        set(ALLOW_STORM_SYSTEM OFF)
+        set(ALLOW_STORM_FETCH ON)
+        
+        if(NOT STORM_ORIGIN_REPO STREQUAL "")
+            set(STORM_GIT_REPO "${STORM_ORIGIN_REPO}")
+        else()
+            message(FATAL_ERROR "PAYNT - Failed to determine Storm origin repository")
+        endif()
+        
+        if(NOT STORM_ORIGIN_TAG STREQUAL "")
+            set(STORM_GIT_TAG "${STORM_ORIGIN_TAG}")
+        else()
+            message(FATAL_ERROR "PAYNT - Failed to determine Storm origin tag")
+        endif()
+        
+        message(STATUS "PAYNT - Configured to fetch Storm from: ${STORM_GIT_REPO} (tag: ${STORM_GIT_TAG})")
     endif()
-    
-    if(NOT STORM_ORIGIN_TAG STREQUAL "")
-        set(STORM_GIT_TAG "${STORM_ORIGIN_TAG}")
-    else()
-        message(FATAL_ERROR "PAYNT - Failed to determine Storm origin tag")
-    endif()
-    
-    message(STATUS "PAYNT - Configured to fetch Storm from: ${STORM_GIT_REPO} (tag: ${STORM_GIT_TAG})")
 endif()
 
 # IMPORTANT: propagate the computed Storm configuration into the CMake cache.
@@ -96,6 +100,7 @@ set(ALLOW_STORM_SYSTEM "${ALLOW_STORM_SYSTEM}" CACHE BOOL "Allow finding a storm
 set(ALLOW_STORM_FETCH "${ALLOW_STORM_FETCH}" CACHE BOOL "Allow fetching storm" FORCE)
 set(STORM_GIT_REPO "${STORM_GIT_REPO}" CACHE STRING "Git repo used for fetching storm" FORCE)
 set(STORM_GIT_TAG "${STORM_GIT_TAG}" CACHE STRING "Git repo tag used for fetching storm" FORCE)
+set(PAYNT_INFO_PRETEND_FETCH "${PAYNT_INFO_PRETEND_FETCH}" CACHE BOOL " [INTERNAL] Use for overriding some flags in the info by cibuildwheel." FORCE)
 
 
 add_subdirectory(payntbind)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ if (NOT PAYNT_INFO_PRETEND_FETCH)
         endif()
         
         # Parse repo and tag
+        # We actually take the repo and commit hash information because we want to match the exact commit of Storm that was used
+        # TODO maybe rename it to be less confusing, however be careful how this influences what information is stored in payntbind info
         list(GET STORM_ORIGIN_INFO 0 STORM_ORIGIN_REPO)
         list(GET STORM_ORIGIN_INFO 2 STORM_ORIGIN_TAG)
         

--- a/payntbind/CMakeLists.txt
+++ b/payntbind/CMakeLists.txt
@@ -72,8 +72,8 @@ if(ALLOW_STORM_SYSTEM)
         get_filename_component(STORM_DIR_PATH ${storm_DIR} ABSOLUTE)
         set(STORM_DIR "\"${STORM_DIR_PATH}\"")
         if (PAYNT_INFO_PRETEND_FETCH)
-            # This is a workaround for our wheel construction which uses a system version for efficiency,
-            # but should provide wheels as if it they were fetched.
+            # This is a workaround for our wheel construction which uses a system version of Storm for efficiency,
+            # but should provide wheels as if they were build against a fetched version of Storm.
             message(WARNING "PAYNT - The behavior of PAYNT_INFO_PRETEND_FETCH is something we only want when building wheels. Please ensure that STORM_GIT_REPO and STORM_GIT_TAG are set accordingly.")
             set(STORM_FETCHED_FROM_REPO ${STORM_GIT_REPO})
             set(STORM_FETCHED_FROM_TAG ${STORM_GIT_TAG})

--- a/payntbind/CMakeLists.txt
+++ b/payntbind/CMakeLists.txt
@@ -17,6 +17,8 @@ set(STORM_GIT_REPO "" CACHE STRING  "Git repo used for fetching storm")
 set(STORM_GIT_TAG "" CACHE STRING "Git repo tag used for fetching storm")
 option(COMPILE_WITH_CCACHE "Compile using CCache (if found)" ON)
 mark_as_advanced(COMPILE_WITH_CCACHE)
+option(PAYNT_INFO_PRETEND_FETCH "[INTERNAL] Use for overriding some flags in the info by cibuildwheel." OFF)
+mark_as_advanced(PAYNT_INFO_PRETEND_FETCH)
 
 # Check whether inputs are sane.
 if (NOT ALLOW_STORM_SYSTEM AND NOT ALLOW_STORM_FETCH)
@@ -57,55 +59,78 @@ if(ALLOW_STORM_SYSTEM)
     else()
         find_package(storm REQUIRED HINTS ${STORM_DIR_HINT}) # REQUIRED, cannot be fetched.
     endif()
-    check_hint("Storm" ${storm_DIR} "${STORM_DIR_HINT}" ${storm_VERSION})
-    # Check Storm version
-    if (${storm_VERSION} VERSION_LESS ${STORM_MIN_VERSION})
-        MESSAGE(FATAL_ERROR "PAYNT - Storm version ${storm_VERSION} from ${storm_DIR} is not supported anymore!\nPAYNT requires at least Storm version >= ${STORM_MIN_VERSION}.")
+    if (storm_FOUND)
+        check_hint("Storm" ${storm_DIR} "${STORM_DIR_HINT}" ${storm_VERSION})
+        # Check Storm version
+        if (${storm_VERSION} VERSION_LESS ${STORM_MIN_VERSION})
+            MESSAGE(FATAL_ERROR "PAYNT - Storm version ${storm_VERSION} from ${storm_DIR} is not supported anymore!\nPAYNT requires at least Storm version >= ${STORM_MIN_VERSION}.")
+        endif()
+
+        message(WARNING "PAYNT - When using system version of Storm, it's up to the user to ensure StormPy was built against the same version!")
+
+        set(STORM_FROM_SYSTEM TRUE)
+        get_filename_component(STORM_DIR_PATH ${storm_DIR} ABSOLUTE)
+        set(STORM_DIR "\"${STORM_DIR_PATH}\"")
+        if (PAYNT_INFO_PRETEND_FETCH)
+            # This is a workaround for our wheel construction which uses a system version for efficiency,
+            # but should provide wheels as if it they were fetched.
+            message(WARNING "PAYNT - The behavior of PAYNT_INFO_PRETEND_FETCH is something we only want when building wheels. Please ensure that STORM_GIT_REPO and STORM_GIT_TAG are set accordingly.")
+            set(STORM_FETCHED_FROM_REPO ${STORM_GIT_REPO})
+            set(STORM_FETCHED_FROM_TAG ${STORM_GIT_TAG})
+            set(STORM_FROM_SYSTEM FALSE)
+            set(STORM_DIR "None")
+        endif()
+
+        # Set dependency variables
+        set_dependency_var(SPOT)
+        set_dependency_var(XERCES)
+        # Check for optional Storm libraries
+        storm_with_lib(DFT)
+        storm_with_lib(GSPN)
+        storm_with_lib(PARS)
+        storm_with_lib(POMDP)
+    elseif (STORM_DIR_HINT)
+        MESSAGE(FATAL_ERROR "PAYNT - Storm could not be found in ${STORM_DIR_HINT}.")
     endif()
-
-    message(WARNING "PAYNT - When using system version of Storm, it's up to the user to ensure StormPy was built against the same version!")
-
-    set(STORM_FROM_SYSTEM TRUE)
-    get_filename_component(STORM_DIR_PATH ${storm_DIR} ABSOLUTE)
-    set(STORM_DIR "\"${STORM_DIR_PATH}\"")
-
-    # Set dependency variables
-    set_dependency_var(SPOT)
-    set_dependency_var(XERCES)
-    # Check for optional Storm libraries
-    storm_with_lib(DFT)
-    storm_with_lib(GSPN)
-    storm_with_lib(PARS)
-    storm_with_lib(POMDP)
 endif ()
-if (NOT storm_FOUND AND ALLOW_STORM_FETCH)
-    include(FetchContent)
-    SET(FETCHCONTENT_QUIET OFF)
-    SET(STORM_BUILD_EXECUTABLES OFF)
-    FetchContent_Declare(
-            storm
-            GIT_REPOSITORY ${STORM_GIT_REPO}
-            GIT_TAG        ${STORM_GIT_TAG}
-    )
-    FETCHCONTENT_MAKEAVAILABLE(storm)
-    include(${storm_BINARY_DIR}/stormOptions.cmake)
-    set(HAVE_STORM_DFT TRUE)
-    set(HAVE_STORM_GSPN TRUE)
-    set(HAVE_STORM_PARS TRUE)
-    set(HAVE_STORM_POMDP TRUE)
-    # Set dependency variables
-    set_dependency_var(SPOT)
-    set_dependency_var(XERCES)
-    if (FETCHCONTENT_SOURCE_DIR_storm)
-        # We are setting the Storm source to be something local from the outside.
-        set(STORM_FETCHED_FROM_REPO ${FETCHCONTENT_SOURCE_DIR_storm})
-        set(STORM_FETCHED_FROM_TAG "__local-source-dir__")
+
+if (NOT storm_FOUND)
+    if (ALLOW_STORM_FETCH)
+        if (PAYNT_INFO_PRETEND_FETCH)
+            message(FATAL_ERROR "PAYNT - Do not set PAYNT_INFO_PRETEND_FETCH when fetching." )
+        endif()
+        # Storm not yet available.
+        include(FetchContent)
+        SET(FETCHCONTENT_QUIET OFF)
+        SET(STORM_BUILD_EXECUTABLES OFF)
+        FetchContent_Declare(
+                storm
+                GIT_REPOSITORY ${STORM_GIT_REPO}
+                GIT_TAG        ${STORM_GIT_TAG}
+        )
+        FETCHCONTENT_MAKEAVAILABLE(storm)
+        include(${storm_BINARY_DIR}/stormOptions.cmake)
+        set(HAVE_STORM_DFT TRUE)
+        set(HAVE_STORM_GSPN TRUE)
+        set(HAVE_STORM_PARS TRUE)
+        set(HAVE_STORM_POMDP TRUE)
+        # Set dependency variables
+        set_dependency_var(SPOT)
+        set_dependency_var(XERCES)
+        if (FETCHCONTENT_SOURCE_DIR_storm)
+            # We are setting the Storm source to be something local from the outside.
+            set(STORM_FETCHED_FROM_REPO ${FETCHCONTENT_SOURCE_DIR_storm})
+            set(STORM_FETCHED_FROM_TAG "__local-source-dir__")
+        else()
+            set(STORM_FETCHED_FROM_REPO ${STORM_GIT_REPO})
+            set(STORM_FETCHED_FROM_TAG ${STORM_GIT_TAG})
+        endif()
+        set(STORM_FROM_SYSTEM FALSE)
+        set(STORM_DIR "None")
     else()
-        set(STORM_FETCHED_FROM_REPO ${STORM_GIT_REPO})
-        set(STORM_FETCHED_FROM_TAG ${STORM_GIT_TAG})
+        # Should not be reachable because storm is required if we cannot fetch it.
+        message(FATAL_ERROR "PAYNT - No version of Storm configured. This situation should not occur. Please contact the PAYNT developers.")
     endif()
-    set(STORM_FROM_SYSTEM FALSE)
-    set(STORM_DIR "None")
 endif()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib/payntbind")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.12.2", "pybind11>=3.0.2", "stormpy>=1.12.0"]
+requires = ["scikit-build-core>=0.12.2", "pybind11>=3.0.4", "stormpy>=1.12.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -88,6 +88,9 @@ repair-wheel-command = "auditwheel show --disable-isa-ext-check {wheel} && audit
 [tool.cibuildwheel.macos]
 before-all = ".github/workflows/before-all-macos.sh"
 repair-wheel-command = "delocate-listdeps -vv --depending --all {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.config-settings]
+"cmake.args" = ["-DSTORM_PORTABLE=ON", "-DALLOW_STORM_SYSTEM='ON'", "-DALLOW_STORM_FETCH='OFF'", "-DPAYNT_INFO_PRETEND_FETCH='ON'"]
 
 [tool.black]
 line-length = 160

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ before-all = ".github/workflows/before-all-macos.sh"
 repair-wheel-command = "delocate-listdeps -vv --depending --all {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.config-settings]
-"cmake.args" = ["-DSTORM_PORTABLE=ON", "-DALLOW_STORM_SYSTEM='ON'", "-DALLOW_STORM_FETCH='OFF'", "-DPAYNT_INFO_PRETEND_FETCH='ON'"]
+"cmake.args" = ["-DSTORM_PORTABLE=ON", "-DALLOW_STORM_SYSTEM=ON", "-DALLOW_STORM_FETCH=OFF", "-DPAYNT_INFO_PRETEND_FETCH=ON"]
 
 [tool.black]
 line-length = 160


### PR DESCRIPTION
The create wheels workflow now build payntbind against a local installation of Storm, but adds information about the Storm version as if it was built against a fetched version akin to the stormpy create wheels workflow. This speeds up the whole process a lot.